### PR TITLE
Update the README.md with official name of gRPC.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Spring Grpc [![build status](https://github.com/spring-projects-experimental/spring-grpc/actions/workflows/deploy.yml/badge.svg)](https://github.com/spring-projects/spring-ai/actions/workflows/deploy.yml)
+# Spring gRPC [![build status](https://github.com/spring-projects-experimental/spring-grpc/actions/workflows/deploy.yml/badge.svg)](https://github.com/spring-projects/spring-ai/actions/workflows/deploy.yml)
 
-Welcome to the Spring Grpc project!
+Welcome to the Spring gRPC project!
 
-The Spring Grpc project provides a Spring-friendly API and abstractions for developing Grpc applications.
+The Spring gRPC project provides a Spring-friendly API and abstractions for developing gRPC applications.
 
-For further information go to our [Spring Grpc reference documentation](https://docs.spring.io/spring-grpc/reference/).
+For further information go to our [Spring gRPC reference documentation](https://docs.spring.io/spring-grpc/reference/).
 


### PR DESCRIPTION
The official name in the documents, such as on the [grpc.io](grpc.io), is `gRPC`, update the README.md to align with it. In the Java implementation, grpc/grpc-java repo, we usually:
- Use `grpc` in the package name, such as io.grpc
- Use `Grpc` in the class name, such as [Grpc.java](https://github.com/grpc/grpc-java/blob/master/api/src/main/java/io/grpc/Grpc.java)