### PR TITLE
Add keep-alive and inbound limits server properties

### DIFF
--- a/spring-grpc-spring-boot-autoconfigure/pom.xml
+++ b/spring-grpc-spring-boot-autoconfigure/pom.xml
@@ -23,6 +23,12 @@
 	<dependencies>
 
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
 			<groupId>com.google.protobuf</groupId>
 			<artifactId>protobuf-java</artifactId>
 			<version>${protobuf-java.version}</version>

--- a/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/server/GrpcServerProperties.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/server/GrpcServerProperties.java
@@ -49,13 +49,13 @@ public class GrpcServerProperties {
 	 * shutdown immediately. The default is 30 seconds.
 	 */
 	@DurationUnit(ChronoUnit.SECONDS)
-	private Duration shutdownGracePeriod = Duration.of(30, ChronoUnit.SECONDS);
+	private Duration shutdownGracePeriod = Duration.ofSeconds(30);
 
 	/**
 	 * Maximum message size allowed to be received by the server (default 4MiB).
 	 */
 	@DataSizeUnit(DataUnit.BYTES)
-	private DataSize maxInboundMessageSize = DataSize.ofBytes(4 * 1024 * 1024);
+	private DataSize maxInboundMessageSize = DataSize.ofBytes(4194304);
 
 	/**
 	 * Maximum metadata size allowed to be received by the server (default 8KiB).
@@ -115,7 +115,7 @@ public class GrpcServerProperties {
 		 * Duration without read activity before sending a keep alive ping (default 2h).
 		 */
 		@DurationUnit(ChronoUnit.SECONDS)
-		private Duration time = Duration.of(2, ChronoUnit.HOURS);
+		private Duration time = Duration.ofHours(2);
 
 		/**
 		 * Maximum time to wait for read activity after sending a keep alive ping. If
@@ -123,7 +123,7 @@ public class GrpcServerProperties {
 		 * connection (default 20s).
 		 */
 		@DurationUnit(ChronoUnit.SECONDS)
-		private Duration timeout = Duration.of(20, ChronoUnit.SECONDS);
+		private Duration timeout = Duration.ofSeconds(20);
 
 		/**
 		 * Maximum time a connection can remain idle before being gracefully terminated
@@ -149,7 +149,7 @@ public class GrpcServerProperties {
 		 * Maximum keep-alive time clients are permitted to configure (default 5m).
 		 */
 		@DurationUnit(ChronoUnit.SECONDS)
-		private Duration permitTime = Duration.of(5, ChronoUnit.MINUTES);
+		private Duration permitTime = Duration.ofMinutes(5);
 
 		/**
 		 * Whether clients are permitted to send keep alive pings when there are no

--- a/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/server/GrpcServerProperties.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/server/GrpcServerProperties.java
@@ -19,7 +19,10 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.convert.DataSizeUnit;
 import org.springframework.boot.convert.DurationUnit;
+import org.springframework.util.unit.DataSize;
+import org.springframework.util.unit.DataUnit;
 
 @ConfigurationProperties(prefix = "spring.grpc.server")
 public class GrpcServerProperties {
@@ -30,22 +33,13 @@ public class GrpcServerProperties {
 	public static final String ANY_IP_ADDRESS = "*";
 
 	/**
-	 * Server should listen to any IPv4 address.
-	 */
-	public static final String ANY_IPv4_ADDRESS = "0.0.0.0";
-
-	/**
-	 * Server should listen to any IPv6 address.
-	 */
-	public static final String ANY_IPv6_ADDRESS = "::";
-
-	/**
 	 * Server address to bind to. The default is any IP address ('*').
 	 */
 	private String address = ANY_IP_ADDRESS;
 
 	/**
 	 * Server port to listen on. When the value is 0, a random available port is selected.
+	 * The default is 9090.
 	 */
 	private int port = 9090;
 
@@ -57,10 +51,22 @@ public class GrpcServerProperties {
 	@DurationUnit(ChronoUnit.SECONDS)
 	private Duration shutdownGracePeriod = Duration.of(30, ChronoUnit.SECONDS);
 
+	/**
+	 * Maximum message size allowed to be received by the server (default 4MiB).
+	 */
+	@DataSizeUnit(DataUnit.BYTES)
+	private DataSize maxInboundMessageSize = DataSize.ofBytes(4 * 1024 * 1024);
+
+	/**
+	 * Maximum metadata size allowed to be received by the server (default 8KiB).
+	 */
+	@DataSizeUnit(DataUnit.BYTES)
+	private DataSize maxInboundMetadataSize = DataSize.ofBytes(8192);
+
 	private final KeepAlive keepAlive = new KeepAlive();
 
 	public String getAddress() {
-		return address;
+		return this.address;
 	}
 
 	public void setAddress(String address) {
@@ -68,7 +74,7 @@ public class GrpcServerProperties {
 	}
 
 	public int getPort() {
-		return port;
+		return this.port;
 	}
 
 	public void setPort(int port) {
@@ -76,11 +82,27 @@ public class GrpcServerProperties {
 	}
 
 	public Duration getShutdownGracePeriod() {
-		return shutdownGracePeriod;
+		return this.shutdownGracePeriod;
 	}
 
 	public void setShutdownGracePeriod(Duration shutdownGracePeriod) {
 		this.shutdownGracePeriod = shutdownGracePeriod;
+	}
+
+	public DataSize getMaxInboundMessageSize() {
+		return this.maxInboundMessageSize;
+	}
+
+	public void setMaxInboundMessageSize(DataSize maxInboundMessageSize) {
+		this.maxInboundMessageSize = maxInboundMessageSize;
+	}
+
+	public DataSize getMaxInboundMetadataSize() {
+		return this.maxInboundMetadataSize;
+	}
+
+	public void setMaxInboundMetadataSize(DataSize maxInboundMetadataSize) {
+		this.maxInboundMetadataSize = maxInboundMetadataSize;
 	}
 
 	public KeepAlive getKeepAlive() {
@@ -103,8 +125,40 @@ public class GrpcServerProperties {
 		@DurationUnit(ChronoUnit.SECONDS)
 		private Duration timeout = Duration.of(20, ChronoUnit.SECONDS);
 
+		/**
+		 * Maximum time a connection can remain idle before being gracefully terminated
+		 * (default infinite).
+		 */
+		@DurationUnit(ChronoUnit.SECONDS)
+		private Duration maxIdle = null;
+
+		/**
+		 * Maximum time a connection may exist before being gracefully terminated (default
+		 * infinite).
+		 */
+		@DurationUnit(ChronoUnit.SECONDS)
+		private Duration maxAge = null;
+
+		/**
+		 * Maximum time for graceful connection termination (default infinite).
+		 */
+		@DurationUnit(ChronoUnit.SECONDS)
+		private Duration maxAgeGrace = null;
+
+		/**
+		 * Maximum keep-alive time clients are permitted to configure (default 5m).
+		 */
+		@DurationUnit(ChronoUnit.SECONDS)
+		private Duration permitTime = Duration.of(5, ChronoUnit.MINUTES);
+
+		/**
+		 * Whether clients are permitted to send keep alive pings when there are no
+		 * outstanding RPCs on the connection (default false).
+		 */
+		private boolean permitWithoutCalls = false;
+
 		public Duration getTime() {
-			return time;
+			return this.time;
 		}
 
 		public void setTime(Duration time) {
@@ -112,11 +166,51 @@ public class GrpcServerProperties {
 		}
 
 		public Duration getTimeout() {
-			return timeout;
+			return this.timeout;
 		}
 
 		public void setTimeout(Duration timeout) {
 			this.timeout = timeout;
+		}
+
+		public Duration getMaxIdle() {
+			return this.maxIdle;
+		}
+
+		public void setMaxIdle(Duration maxIdle) {
+			this.maxIdle = maxIdle;
+		}
+
+		public Duration getMaxAge() {
+			return this.maxAge;
+		}
+
+		public void setMaxAge(Duration maxAge) {
+			this.maxAge = maxAge;
+		}
+
+		public Duration getMaxAgeGrace() {
+			return this.maxAgeGrace;
+		}
+
+		public void setMaxAgeGrace(Duration maxAgeGrace) {
+			this.maxAgeGrace = maxAgeGrace;
+		}
+
+		public Duration getPermitTime() {
+			return this.permitTime;
+		}
+
+		public void setPermitTime(Duration permitTime) {
+			this.permitTime = permitTime;
+		}
+
+		public boolean isPermitWithoutCalls() {
+			return this.permitWithoutCalls;
+		}
+
+		public void setPermitWithoutCalls(boolean permitWithoutCalls) {
+			this.permitWithoutCalls = permitWithoutCalls;
 		}
 
 	}

--- a/spring-grpc-spring-boot-autoconfigure/src/test/java/org/springframework/grpc/autoconfigure/server/ServerFactoryPropertyMappersTests.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/test/java/org/springframework/grpc/autoconfigure/server/ServerFactoryPropertyMappersTests.java
@@ -24,6 +24,8 @@ import java.util.function.Supplier;
 import io.grpc.ServerBuilder;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.util.unit.DataSize;
+
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 
@@ -59,11 +61,25 @@ class ServerFactoryPropertyMappersTests {
 		GrpcServerProperties properties = new GrpcServerProperties();
 		properties.getKeepAlive().setTime(Duration.ofHours(1));
 		properties.getKeepAlive().setTimeout(Duration.ofSeconds(10));
+		properties.getKeepAlive().setMaxIdle(Duration.ofHours(2));
+		properties.getKeepAlive().setMaxAge(Duration.ofHours(3));
+		properties.getKeepAlive().setMaxAgeGrace(Duration.ofSeconds(45));
+		properties.getKeepAlive().setPermitTime(Duration.ofMinutes(7));
+		properties.getKeepAlive().setPermitWithoutCalls(true);
+		properties.setMaxInboundMessageSize(DataSize.ofMegabytes(333));
+		properties.setMaxInboundMetadataSize(DataSize.ofKilobytes(111));
 		X mapper = mapperFactory.apply(properties);
 		T builder = mockBuilderToCustomize.get();
 		mapper.customizeServerBuilder(builder);
 		then(builder).should().keepAliveTime(Duration.ofHours(1).toNanos(), TimeUnit.NANOSECONDS);
 		then(builder).should().keepAliveTimeout(Duration.ofSeconds(10).toNanos(), TimeUnit.NANOSECONDS);
+		then(builder).should().maxConnectionIdle(Duration.ofHours(2).toNanos(), TimeUnit.NANOSECONDS);
+		then(builder).should().maxConnectionAge(Duration.ofHours(3).toNanos(), TimeUnit.NANOSECONDS);
+		then(builder).should().maxConnectionAgeGrace(Duration.ofSeconds(45).toNanos(), TimeUnit.NANOSECONDS);
+		then(builder).should().permitKeepAliveTime(Duration.ofMinutes(7).toNanos(), TimeUnit.NANOSECONDS);
+		then(builder).should().permitKeepAliveWithoutCalls(true);
+		then(builder).should().maxInboundMessageSize(Math.toIntExact(DataSize.ofMegabytes(333).toBytes()));
+		then(builder).should().maxInboundMetadataSize(Math.toIntExact(DataSize.ofKilobytes(111).toBytes()));
 	}
 
 }


### PR DESCRIPTION
**Commit 1: Add keep-alive and inbound limits server properties**

Resolves #6

> [!NOTE]
> I piggybacked the following feature on commit 2 (it is related and builds upon the first commit)

**Commit 2: Generate metadata for config props**
Adds the `spring-boot-configuration-processor` to enable automatic metadata
generation so our config props play well in IDEs.

Also updates the default values for duration properties to use
`Duration.of<Unit>(long)` instead of `Duration.of(long, DurationUnit)` as
Spring Boot config processor can not determine a default for the config
metadata in the latter format.