### PR TITLE
Refactors dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,20 +74,15 @@
 		<maven.compiler.target>17</maven.compiler.target>
 
 		<!-- production dependencies -->
-		<spring-cloud-function-context.version>4.1.3</spring-cloud-function-context.version>
-		<spring-boot.version>3.3.3</spring-boot.version>
-		<spring-framework.version>6.1.4</spring-framework.version>
+		<spring-framework.version>6.1.14</spring-framework.version>
+		<netty.version>4.1.113.Final</netty.version>
+		<protobuf-java.version>3.25.5</protobuf-java.version>
+		<grpc.version>1.63.2</grpc.version>
 
-		<!-- Protobuf -->
-		<protobuf-java.version>3.25.2</protobuf-java.version>
-		<grpc.version>1.63.0</grpc.version>
-
-		<!-- testing dependencies -->
-		<httpclient5.version>5.3.1</httpclient5.version>
-
-		<!-- testing dependencies -->
-		<testcontainers.version>1.20.1</testcontainers.version>
-		<testcontainers.opensearch.version>2.0.1</testcontainers.opensearch.version>
+		<!-- internal dependencies -->
+		<spring-boot.version>3.3.4</spring-boot.version>
+		<jackson.version>2.17.2</jackson.version>
+		<junit.version>5.10.5</junit.version>
 
 		<!-- documentation dependencies -->
 		<io.spring.maven.antora-version>0.0.4</io.spring.maven.antora-version>
@@ -382,9 +377,16 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-dependencies</artifactId>
-				<version>${spring-boot.version}</version>
+				<groupId>org.springframework</groupId>
+				<artifactId>spring-framework-bom</artifactId>
+				<version>${spring-framework.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-bom</artifactId>
+				<version>${netty.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,8 +76,9 @@
 		<!-- production dependencies -->
 		<spring-framework.version>6.1.14</spring-framework.version>
 		<netty.version>4.1.113.Final</netty.version>
-		<protobuf-java.version>3.25.5</protobuf-java.version>
 		<grpc.version>1.63.2</grpc.version>
+		<protobuf-java.version>3.25.5</protobuf-java.version>
+		<google-common-protos.version>2.46.0</google-common-protos.version>
 
 		<!-- internal dependencies -->
 		<spring-boot.version>3.3.4</spring-boot.version>
@@ -403,6 +404,11 @@
 				<version>${grpc.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>com.google.api.grpc</groupId>
+				<artifactId>proto-google-common-protos</artifactId>
+				<version>${google-common-protos.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/samples/grpc-server/build.gradle
+++ b/samples/grpc-server/build.gradle
@@ -52,7 +52,9 @@ protobuf {
     }
     generateProtoTasks {
         all()*.plugins {
-            grpc {}
-        }
+            grpc {
+				option 'jakarta_omit'
+			}
+		}
     }
 }

--- a/samples/grpc-server/build.gradle
+++ b/samples/grpc-server/build.gradle
@@ -29,7 +29,7 @@ dependencyManagement {
 }
 
 dependencies {
-	implementation 'org.springframework.grpc:spring-grpc-spring-boot-autoconfigure:0.1.0-SNAPSHOT'
+	implementation 'org.springframework.grpc:spring-grpc-spring-boot-autoconfigure'
 	implementation 'io.grpc:grpc-services'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.grpc:spring-grpc-test'

--- a/samples/grpc-server/pom.xml
+++ b/samples/grpc-server/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.3</version>
+		<version>3.3.4</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.springframework.grpc</groupId>
@@ -30,22 +30,15 @@
 	<properties>
 		<java.version>17</java.version>
 		<spring-javaformat-maven-plugin.version>0.0.39</spring-javaformat-maven-plugin.version>
-		<protobuf-java.version>3.25.2</protobuf-java.version>
-		<grpc.version>1.63.0</grpc.version>
+		<protobuf-java.version>3.25.5</protobuf-java.version>
+		<grpc.version>1.63.2</grpc.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
 				<groupId>org.springframework.grpc</groupId>
 				<artifactId>spring-grpc-bom</artifactId>
-				<version>0.1.0-SNAPSHOT</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.grpc</groupId>
-				<artifactId>spring-grpc</artifactId>
-				<version>0.1.0-SNAPSHOT</version>
+				<version>${project.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -60,7 +53,6 @@
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-services</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/samples/grpc-server/pom.xml
+++ b/samples/grpc-server/pom.xml
@@ -120,14 +120,6 @@
 				<groupId>org.xolstice.maven.plugins</groupId>
 				<artifactId>protobuf-maven-plugin</artifactId>
 				<version>0.6.1</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>compile</goal>
-							<goal>compile-custom</goal>
-						</goals>
-					</execution>
-				</executions>
 				<configuration>
 					<protocArtifact>
 						com.google.protobuf:protoc:${protobuf-java.version}:exe:${os.detected.classifier}</protocArtifact>
@@ -135,6 +127,19 @@
 					<pluginArtifact>
 						io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
 				</configuration>
+				<executions>
+					<execution>
+						<configuration>
+							<pluginParameter>
+								jakarta_omit
+							</pluginParameter>
+						</configuration>
+						<goals>
+							<goal>compile</goal>
+							<goal>compile-custom</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/spring-grpc-core/pom.xml
+++ b/spring-grpc-core/pom.xml
@@ -21,7 +21,6 @@
 	</scm>
 
 	<dependencies>
-
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
@@ -54,10 +53,10 @@
 			<version>1.3.2</version>
 		</dependency>
 
-		<!-- test dependencies -->
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>${junit.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/spring-grpc-core/pom.xml
+++ b/spring-grpc-core/pom.xml
@@ -42,7 +42,26 @@
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-protobuf</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>com.google.protobuf</groupId>
+					<artifactId>protobuf-java</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.api.grpc</groupId>
+					<artifactId>proto-google-common-protos</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
+		<dependency>
+			<groupId>com.google.protobuf</groupId>
+			<artifactId>protobuf-java</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.google.api.grpc</groupId>
+			<artifactId>proto-google-common-protos</artifactId>
+		</dependency>
+
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-stub</artifactId>

--- a/spring-grpc-core/pom.xml
+++ b/spring-grpc-core/pom.xml
@@ -47,11 +47,6 @@
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-stub</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>javax.annotation</groupId>
-			<artifactId>javax.annotation-api</artifactId>
-			<version>1.3.2</version>
-		</dependency>
 
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/spring-grpc-docs/pom.xml
+++ b/spring-grpc-docs/pom.xml
@@ -20,17 +20,14 @@
 	<!-- Dependencies used to build the config props doc generator -->
 	<dependencies>
 		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-core</artifactId>
+			<groupId>org.springframework.grpc</groupId>
+			<artifactId>spring-grpc-spring-boot-autoconfigure</artifactId>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.grpc</groupId>
-			<artifactId>spring-grpc-spring-boot-autoconfigure</artifactId>
-			<version>${project.version}</version>
+			<version>${jackson.version}</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/spring-grpc-spring-boot-autoconfigure/pom.xml
+++ b/spring-grpc-spring-boot-autoconfigure/pom.xml
@@ -54,11 +54,6 @@
 			<artifactId>grpc-netty-shaded</artifactId>
 			<optional>true</optional>
 		</dependency>
-		<dependency>
-			<groupId>com.google.protobuf</groupId>
-			<artifactId>protobuf-java</artifactId>
-			<optional>true</optional>
-		</dependency>
 
 		<!-- test dependencies -->
 		<dependency>

--- a/spring-grpc-spring-boot-autoconfigure/pom.xml
+++ b/spring-grpc-spring-boot-autoconfigure/pom.xml
@@ -20,76 +20,56 @@
 		<developerConnection>git@github.com:spring-projects-experimental/spring-grpc.git</developerConnection>
 	</scm>
 
-	<dependencies>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-dependencies</artifactId>
+				<version>${spring-boot.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
+	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
 
-		<dependency>
-			<groupId>com.google.protobuf</groupId>
-			<artifactId>protobuf-java</artifactId>
-			<version>${protobuf-java.version}</version>
-			<optional>true</optional>
-		</dependency>
-
 		<!-- production dependencies -->
-
 		<dependency>
 			<groupId>org.springframework.grpc</groupId>
 			<artifactId>spring-grpc-core</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-netty-shaded</artifactId>
 			<optional>true</optional>
 		</dependency>
+		<dependency>
+			<groupId>com.google.protobuf</groupId>
+			<artifactId>protobuf-java</artifactId>
+			<optional>true</optional>
+		</dependency>
 
 		<!-- test dependencies -->
-
 		<dependency>
 			<groupId>org.springframework.grpc</groupId>
 			<artifactId>spring-grpc-test</artifactId>
 			<version>${project.parent.version}</version>
 			<scope>test</scope>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-testcontainers</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.testcontainers</groupId>
-			<artifactId>testcontainers</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.awaitility</groupId>
-			<artifactId>awaitility</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>io.micrometer</groupId>
-			<artifactId>micrometer-observation-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/spring-grpc-test/pom.xml
+++ b/spring-grpc-test/pom.xml
@@ -26,7 +26,6 @@
 	</properties>
 
 	<dependencies>
-
 		<dependency>
 			<groupId>org.springframework.grpc</groupId>
 			<artifactId>spring-grpc-core</artifactId>
@@ -35,17 +34,6 @@
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-testing</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<exclusions>
-				<exclusion>
-					<groupId>com.vaadin.external.google</groupId>
-					<artifactId>android-json</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
This PR adds a few commits that:

1. [Clean up dependencies and versions](https://github.com/spring-projects-experimental/spring-grpc/commit/29910f9f1ace0bef27e2427c16b8262c4e7f5d9c) 

2. [Remove dependency on javax.annotation](https://github.com/spring-projects-experimental/spring-grpc/commit/b6b2fc37f97335e8cf00dc547056817253897d80) 

3. [Exclude older protofuf lib from grpc lib](https://github.com/spring-projects-experimental/spring-grpc/commit/195c610bdc5fd37f6ed24c2bddb37ea49c30b36a) 

### Details

The `protobuf-java` 3.25.1 has a CVE that is fixed in 3.25.5. I adjusted the versions accordingly in our root pom.xml but noticed that the older 3.25.1 was still being piggy backed in my sample app that is consuming spring-grpc.

Prior to commit 2 and 3 you can see that we are bringing in:
- javax.annotation 
- older protobuf-java:3.25.1

<img width="1075" alt="Screenshot 2024-10-20 at 11 29 27" src="https://github.com/user-attachments/assets/dfa6d901-9993-4edd-a75b-822a1c98577c">


After commit 3 you can see that javax.annotation is gone and protobuf-java is at 3.25.5 and grpc-protofbuf is at 1.63.2

<img width="952" alt="Screenshot 2024-10-20 at 12 13 52" src="https://github.com/user-attachments/assets/d4473763-d1f7-4048-9fb4-4dade62e6621">
