### PR TITLE
Add spring-grpc-spring-boot-starter module

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To create a simple gRPC server, you can use the Spring Boot starter. For Maven:
 ```xml
 <dependency>
 	<groupId>org.springframework.grpc</groupId>
-	<artifactId>spring-grpc-spring-boot-autoconfigure</artifactId>
+	<artifactId>spring-grpc-spring-boot-starter</artifactId>
 	<version>0.1.0-SNAPSHOT</version>
 </dependency>
 ```
@@ -23,7 +23,7 @@ To create a simple gRPC server, you can use the Spring Boot starter. For Maven:
 or for Gradle:
 
 ```groovy
-implementation 'org.springframework.grpc:spring-grpc-spring-boot-autoconfigure:0.1.0-SNAPSHOT'
+implementation 'org.springframework.grpc:spring-grpc-spring-boot-starter:0.1.0-SNAPSHOT'
 ```
 
 For convenience, you can use the Spring gRPC BOM to manage dependencies. With Maven:

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
 		<module>spring-grpc-core</module>
 		<module>spring-grpc-test</module>
 		<module>spring-grpc-spring-boot-autoconfigure</module>
+		<module>spring-grpc-spring-boot-starter</module>
 		<module>samples</module>
 	</modules>
 

--- a/samples/grpc-server/build.gradle
+++ b/samples/grpc-server/build.gradle
@@ -29,7 +29,7 @@ dependencyManagement {
 }
 
 dependencies {
-	implementation 'org.springframework.grpc:spring-grpc-spring-boot-autoconfigure'
+	implementation 'org.springframework.grpc:spring-grpc-spring-boot-starter'
 	implementation 'io.grpc:grpc-services'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.grpc:spring-grpc-test'

--- a/samples/grpc-server/pom.xml
+++ b/samples/grpc-server/pom.xml
@@ -47,7 +47,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.grpc</groupId>
-			<artifactId>spring-grpc-spring-boot-autoconfigure</artifactId>
+			<artifactId>spring-grpc-spring-boot-starter</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>io.grpc</groupId>

--- a/spring-grpc-bom/pom.xml
+++ b/spring-grpc-bom/pom.xml
@@ -26,26 +26,27 @@
 
 	<dependencyManagement>
 		<dependencies>
-
 			<dependency>
 				<groupId>org.springframework.grpc</groupId>
 				<artifactId>spring-grpc-core</artifactId>
 				<version>${project.version}</version>
 			</dependency>
-
+			<dependency>
+				<groupId>org.springframework.grpc</groupId>
+				<artifactId>spring-grpc-spring-boot-autoconfigure</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.grpc</groupId>
+				<artifactId>spring-grpc-spring-boot-starter</artifactId>
+				<version>${project.version}</version>
+			</dependency>
 			<!-- Utilities -->
 			<dependency>
 				<groupId>org.springframework.grpc</groupId>
 				<artifactId>spring-grpc-test</artifactId>
 				<version>${project.version}</version>
 			</dependency>
-
-			<dependency>
-				<groupId>org.springframework.grpc</groupId>
-				<artifactId>spring-grpc-spring-boot-autoconfigure</artifactId>
-				<version>${project.version}</version>
-			</dependency>
-
 		</dependencies>
 	</dependencyManagement>
 

--- a/spring-grpc-docs/pom.xml
+++ b/spring-grpc-docs/pom.xml
@@ -21,7 +21,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.grpc</groupId>
-			<artifactId>spring-grpc-spring-boot-autoconfigure</artifactId>
+			<artifactId>spring-grpc-spring-boot-starter</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>

--- a/spring-grpc-spring-boot-autoconfigure/pom.xml
+++ b/spring-grpc-spring-boot-autoconfigure/pom.xml
@@ -39,27 +39,33 @@
 			<optional>true</optional>
 		</dependency>
 
-		<!-- production dependencies -->
 		<dependency>
 			<groupId>org.springframework.grpc</groupId>
 			<artifactId>spring-grpc-core</artifactId>
-			<version>${project.parent.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<version>${project.version}</version>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-netty-shaded</artifactId>
 			<optional>true</optional>
 		</dependency>
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-transport-native-epoll</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+			<scope>provided</scope>
+		</dependency>
 
 		<!-- test dependencies -->
 		<dependency>
 			<groupId>org.springframework.grpc</groupId>
 			<artifactId>spring-grpc-test</artifactId>
-			<version>${project.parent.version}</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-grpc-spring-boot-starter/pom.xml
+++ b/spring-grpc-spring-boot-starter/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.grpc</groupId>
+		<artifactId>spring-grpc</artifactId>
+		<version>0.1.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>spring-grpc-spring-boot-starter</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring gRPC Spring Boot Starter</name>
+	<description>Spring gRPC Spring Boot Starter</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.grpc</groupId>
+			<artifactId>spring-grpc-core</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.grpc</groupId>
+			<artifactId>spring-grpc-spring-boot-autoconfigure</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+			<version>${spring-boot.version}</version>
+		</dependency>
+	</dependencies>
+
+</project>


### PR DESCRIPTION

This PR does the following:

* Adds a spring-grpc-spring-boot-starter module as described [here](https://docs.spring.io/spring-boot/reference/features/developing-auto-configuration.html#features.developing-auto-configuration.custom-starter.starter-module).
* Adjusts the scope of the dependencies in the spring-grpc-autoconfigure module as [recommended here](https://docs.spring.io/spring-boot/reference/features/developing-auto-configuration.html#features.developing-auto-configuration.custom-starter.autoconfigure-module). 

At first glance, the autoconfigure is simple enough to just combine the starter + autoconfigure in a single module. However, I can envision us having multiple starters in the future (netty, shaded netty, okio, etc...). 

As it currently stands, our default opinion is "netty" over "shaded netty". 

1. Should that be our default?
2. Should we go ahead and name this default starter w/ according suffix, something like the following:?

- spring-grpc-spring-boot-starter-shaded-netty
- spring-grpc-spring-boot-starter-netty
- spring-grpc-spring-boot-starter-okio

