### PR TITLE
Update getting-started.adoc and README.md to fix group ID typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ If you’re a Maven user, you can use the dependencies by adding the following t
 <dependencyManagement>
     <dependencies>
         <dependency>
-            <groupId>org.springframework.ai</groupId>
+            <groupId>org.springframework.grpc</groupId>
             <artifactId>spring-grpc-dependencies</artifactId>
             <version>0.2.0-SNAPSHOT</version>
             <type>pom</type>
@@ -84,7 +84,7 @@ As shown in the snippet below this can then be followed by version-less declarat
 
 ```gradle
 dependencies {
-  implementation platform("org.springframework.ai:spring-grpc-dependencies:0.2.0-SNAPSHOT")
+  implementation platform("org.springframework.grpc:spring-grpc-dependencies:0.2.0-SNAPSHOT")
 }
 ```
 

--- a/spring-grpc-docs/src/main/antora/modules/ROOT/pages/getting-started.adoc
+++ b/spring-grpc-docs/src/main/antora/modules/ROOT/pages/getting-started.adoc
@@ -66,7 +66,7 @@ If you’re a Maven user, you can use the dependencies by adding the following t
 <dependencyManagement>
     <dependencies>
         <dependency>
-            <groupId>org.springframework.ai</groupId>
+            <groupId>org.springframework.grpc</groupId>
             <artifactId>spring-grpc-dependencies</artifactId>
             <version>0.2.0-SNAPSHOT</version>
             <type>pom</type>
@@ -83,7 +83,7 @@ As shown in the snippet below this can then be followed by version-less declarat
 [source,gradle]
 ----
 dependencies {
-  implementation platform("org.springframework.ai:spring-grpc-dependencies:0.2.0-SNAPSHOT")
+  implementation platform("org.springframework.grpc:spring-grpc-dependencies:0.2.0-SNAPSHOT")
 }
 ----
 


### PR DESCRIPTION
When trying to pull down the dependencies from Maven, I noticed there was a typo in the group ID of the dependencies mentioned in the documentation. They use `org.springframework.ai`, when it should be `org.springframework.grpc`. This PR fixes those docs.