### PR TITLE
Add GrpcServiceDiscoverer to prepare for interceptors

### DIFF
--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/GrpcServiceDiscoverer.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/GrpcServiceDiscoverer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2024-2024 The gRPC-Spring Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.grpc.server;
+
+import java.util.List;
+
+import io.grpc.ServerServiceDefinition;
+
+/**
+ * Discovers {@link ServerServiceDefinition gRPC services} to be provided by the server.
+ *
+ * @author Michael (yidongnan@gmail.com)
+ * @author Chris Bono
+ */
+@FunctionalInterface
+public interface GrpcServiceDiscoverer {
+
+	/**
+	 * Find gRPC services for the server to provide.
+	 * @return list of services to add to the server - empty when no services available
+	 */
+	List<ServerServiceDefinition> findServices();
+
+}

--- a/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/server/DefaultGrpcServiceDiscoverer.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/server/DefaultGrpcServiceDiscoverer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2016-2023 The gRPC-Spring Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.grpc.autoconfigure.server;
+
+import java.util.List;
+
+import io.grpc.BindableService;
+import io.grpc.ServerServiceDefinition;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.grpc.server.GrpcServiceDiscoverer;
+
+/**
+ * The default {@link GrpcServiceDiscoverer} that finds all {@link BindableService} beans
+ * and configures and binds them.
+ *
+ * @author Michael (yidongnan@gmail.com)
+ * @author Chris Bono
+ */
+class DefaultGrpcServiceDiscoverer implements GrpcServiceDiscoverer {
+
+	private final ObjectProvider<BindableService> grpcServicesProvider;
+
+	DefaultGrpcServiceDiscoverer(ObjectProvider<BindableService> grpcServicesProvider) {
+		this.grpcServicesProvider = grpcServicesProvider;
+	}
+
+	@Override
+	public List<ServerServiceDefinition> findServices() {
+		return grpcServicesProvider.orderedStream().map(BindableService::bindService).toList();
+	}
+
+}

--- a/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/server/GrpcServerAutoConfiguration.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/server/GrpcServerAutoConfiguration.java
@@ -28,6 +28,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.grpc.autoconfigure.common.codec.GrpcCodecConfiguration;
 import org.springframework.grpc.server.GrpcServerFactory;
+import org.springframework.grpc.server.GrpcServiceDiscoverer;
 import org.springframework.grpc.server.ServerBuilderCustomizer;
 import org.springframework.grpc.server.lifecycle.GrpcServerLifecycle;
 
@@ -67,6 +68,12 @@ public class GrpcServerAutoConfiguration {
 	@Bean
 	ServerBuilderCustomizers serverBuilderCustomizers(ObjectProvider<ServerBuilderCustomizer<?>> customizers) {
 		return new ServerBuilderCustomizers(customizers.orderedStream().toList());
+	}
+
+	@ConditionalOnMissingBean
+	@Bean
+	GrpcServiceDiscoverer grpcServiceDiscoverer(ObjectProvider<BindableService> bindableServicesProvider) {
+		return new DefaultGrpcServiceDiscoverer(bindableServicesProvider);
 	}
 
 }

--- a/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/server/GrpcServerFactoryConfigurations.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/server/GrpcServerFactoryConfigurations.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import javax.net.ssl.KeyManagerFactory;
 
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -30,11 +29,11 @@ import org.springframework.boot.ssl.SslBundles;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.grpc.server.GrpcServerFactory;
+import org.springframework.grpc.server.GrpcServiceDiscoverer;
 import org.springframework.grpc.server.NettyGrpcServerFactory;
 import org.springframework.grpc.server.ServerBuilderCustomizer;
 import org.springframework.grpc.server.ShadedNettyGrpcServerFactory;
 
-import io.grpc.BindableService;
 import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
 import io.grpc.netty.NettyServerBuilder;
@@ -54,7 +53,7 @@ class GrpcServerFactoryConfigurations {
 
 		@Bean
 		ShadedNettyGrpcServerFactory shadedNettyGrpcServerFactory(GrpcServerProperties properties,
-				ObjectProvider<BindableService> grpcServicesProvider, ServerBuilderCustomizers serverBuilderCustomizers,
+				GrpcServiceDiscoverer grpcServicesDiscoverer, ServerBuilderCustomizers serverBuilderCustomizers,
 				SslBundles bundles) {
 			ShadedNettyServerFactoryPropertyMapper mapper = new ShadedNettyServerFactoryPropertyMapper(properties);
 			List<ServerBuilderCustomizer<io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder>> builderCustomizers = List
@@ -66,7 +65,7 @@ class GrpcServerFactoryConfigurations {
 			}
 			ShadedNettyGrpcServerFactory factory = new ShadedNettyGrpcServerFactory(properties.getAddress(), keyManager,
 					builderCustomizers);
-			grpcServicesProvider.orderedStream().map(BindableService::bindService).forEach(factory::addService);
+			grpcServicesDiscoverer.findServices().forEach(factory::addService);
 			return factory;
 		}
 
@@ -94,7 +93,7 @@ class GrpcServerFactoryConfigurations {
 
 		@Bean
 		NettyGrpcServerFactory nettyGrpcServerFactory(GrpcServerProperties properties,
-				ObjectProvider<BindableService> grpcServicesProvider, ServerBuilderCustomizers serverBuilderCustomizers,
+				GrpcServiceDiscoverer grpcServicesDiscoverer, ServerBuilderCustomizers serverBuilderCustomizers,
 				SslBundles bundles) {
 			NettyServerFactoryPropertyMapper mapper = new NettyServerFactoryPropertyMapper(properties);
 			List<ServerBuilderCustomizer<NettyServerBuilder>> builderCustomizers = List
@@ -106,7 +105,7 @@ class GrpcServerFactoryConfigurations {
 			}
 			NettyGrpcServerFactory factory = new NettyGrpcServerFactory(properties.getAddress(), keyManager,
 					builderCustomizers);
-			grpcServicesProvider.orderedStream().map(BindableService::bindService).forEach(factory::addService);
+			grpcServicesDiscoverer.findServices().forEach(factory::addService);
 			return factory;
 		}
 


### PR DESCRIPTION
This commit re-introduces the service discoverer concept from the gRPC ecosystem. We previously removed it but realized that the abstraction is helpful to provide fully configured service definitions with features like server interceptors. The next commit will take advantage of this commit to add interceptors.

See #4