### PR TITLE
Add autoconfig for reflection service and friends #26

### DIFF
--- a/samples/grpc-server/src/main/java/org/springframework/grpc/sample/GrpcServerApplication.java
+++ b/samples/grpc-server/src/main/java/org/springframework/grpc/sample/GrpcServerApplication.java
@@ -2,21 +2,12 @@ package org.springframework.grpc.sample;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
-
-import io.grpc.BindableService;
-import io.grpc.protobuf.services.ProtoReflectionService;
 
 @SpringBootApplication
 public class GrpcServerApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(GrpcServerApplication.class, args);
-	}
-
-	@Bean
-	public BindableService serverReflection() {
-		return ProtoReflectionService.newInstance();
 	}
 
 }

--- a/samples/grpc-server/src/main/resources/application.properties
+++ b/samples/grpc-server/src/main/resources/application.properties
@@ -1,2 +1,2 @@
 spring.application.name=grpc-server
-grpc.server.reflection.enabled=false
+spring.grpc.server.reflection.enabled=true

--- a/samples/grpc-server/src/main/resources/application.properties
+++ b/samples/grpc-server/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=grpc-server
+grpc.server.reflection.enabled=false

--- a/samples/grpc-tomcat/src/main/java/org/springframework/grpc/sample/GrpcServerApplication.java
+++ b/samples/grpc-tomcat/src/main/java/org/springframework/grpc/sample/GrpcServerApplication.java
@@ -2,10 +2,6 @@ package org.springframework.grpc.sample;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
-
-import io.grpc.BindableService;
-import io.grpc.protobuf.services.ProtoReflectionService;
 
 @SpringBootApplication
 public class GrpcServerApplication {
@@ -13,10 +9,4 @@ public class GrpcServerApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(GrpcServerApplication.class, args);
 	}
-
-	@Bean
-	public BindableService serverReflection() {
-		return ProtoReflectionService.newInstance();
-	}
-
 }

--- a/spring-grpc-spring-boot-autoconfigure/pom.xml
+++ b/spring-grpc-spring-boot-autoconfigure/pom.xml
@@ -88,7 +88,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-services</artifactId>
+        </dependency>
 
-	</dependencies>
+    </dependencies>
 
 </project>

--- a/spring-grpc-spring-boot-autoconfigure/pom.xml
+++ b/spring-grpc-spring-boot-autoconfigure/pom.xml
@@ -62,6 +62,11 @@
 		</dependency>
 		<dependency>
 			<groupId>io.grpc</groupId>
+			<artifactId>grpc-services</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>io.grpc</groupId>
 			<artifactId>grpc-netty-shaded</artifactId>
 			<optional>true</optional>
 		</dependency>
@@ -88,10 +93,6 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-services</artifactId>
-        </dependency>
 
     </dependencies>
 

--- a/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/server/GrpcServerFactoryAutoConfiguration.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/server/GrpcServerFactoryAutoConfiguration.java
@@ -23,6 +23,7 @@ import io.grpc.servlet.jakarta.GrpcServlet;
 import io.grpc.servlet.jakarta.ServletServerBuilder;
 
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureOrder;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -48,6 +49,7 @@ import org.springframework.util.unit.DataSize;
  * @author Toshiaki Maki
  */
 @AutoConfiguration
+@AutoConfigureAfter(GrpcServerReflectionAutoConfiguration.class)
 @AutoConfigureOrder(Ordered.HIGHEST_PRECEDENCE)
 @ConditionalOnClass(BindableService.class)
 @ConditionalOnBean(BindableService.class)

--- a/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/server/GrpcServerReflectionAutoConfiguration.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/server/GrpcServerReflectionAutoConfiguration.java
@@ -27,4 +27,5 @@ public class GrpcServerReflectionAutoConfiguration {
 	public BindableService serverReflection() {
 		return ProtoReflectionService.newInstance();
 	}
+
 }

--- a/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/server/GrpcServerReflectionAutoConfiguration.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/server/GrpcServerReflectionAutoConfiguration.java
@@ -12,7 +12,8 @@ import io.grpc.protobuf.services.ProtoReflectionService;
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for gRPC Reflection service
  * <p>
- * spring.grpc.reflection.enabled=true must be present in configuration in order for the
+ * This auto-configuration is enabled by default. To disable it, set the configuration
+ * flag {spring.grpc.server.reflection.enabled=false} in your application properties.
  * auto-configuration to execute
  *
  * @author Haris Zujo

--- a/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/server/GrpcServerReflectionAutoConfiguration.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/server/GrpcServerReflectionAutoConfiguration.java
@@ -18,7 +18,7 @@ import io.grpc.protobuf.services.ProtoReflectionService;
  * @author Haris Zujo
  */
 @Configuration
-@ConditionalOnClass(BindableService.class)
+@ConditionalOnClass(ProtoReflectionService.class)
 public class GrpcServerReflectionAutoConfiguration {
 
 	@Bean

--- a/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/server/GrpcServerReflectionAutoConfiguration.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/server/GrpcServerReflectionAutoConfiguration.java
@@ -1,0 +1,30 @@
+package org.springframework.grpc.autoconfigure.server;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.grpc.BindableService;
+import io.grpc.protobuf.services.ProtoReflectionService;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for gRPC Reflection service
+ * <p>
+ * grpc.reflection.enabled=true must be present in configuration in order for the
+ * auto-configuration to execute
+ *
+ * @author Haris Zujo
+ */
+@Configuration
+@ConditionalOnClass(BindableService.class)
+public class GrpcServerReflectionAutoConfiguration {
+
+	@Bean
+	@ConditionalOnProperty(name = "grpc.server.reflection.enabled", havingValue = "true")
+	public BindableService serverReflection() {
+		return ProtoReflectionService.newInstance();
+	}
+
+}

--- a/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/server/GrpcServerReflectionAutoConfiguration.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/server/GrpcServerReflectionAutoConfiguration.java
@@ -1,10 +1,10 @@
 package org.springframework.grpc.autoconfigure.server;
 
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 import io.grpc.BindableService;
 import io.grpc.protobuf.services.ProtoReflectionService;
@@ -12,19 +12,18 @@ import io.grpc.protobuf.services.ProtoReflectionService;
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for gRPC Reflection service
  * <p>
- * grpc.reflection.enabled=true must be present in configuration in order for the
+ * spring.grpc.reflection.enabled=true must be present in configuration in order for the
  * auto-configuration to execute
  *
  * @author Haris Zujo
  */
-@Configuration
+@AutoConfiguration
 @ConditionalOnClass(ProtoReflectionService.class)
+@ConditionalOnProperty(name = "spring.grpc.server.reflection.enabled", havingValue = "true", matchIfMissing = true)
 public class GrpcServerReflectionAutoConfiguration {
 
 	@Bean
-	@ConditionalOnProperty(name = "grpc.server.reflection.enabled", havingValue = "true")
 	public BindableService serverReflection() {
 		return ProtoReflectionService.newInstance();
 	}
-
 }

--- a/spring-grpc-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-grpc-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -4,6 +4,10 @@
     {
       "name": "spring.grpc.server.port",
       "defaultValue": "9090"
+    },
+    {
+      "name": "spring.grpc.server.reflection.enabled",
+      "defaultValue": "true"
     }
   ]
 }

--- a/spring-grpc-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-grpc-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,3 +1,5 @@
 org.springframework.grpc.autoconfigure.server.GrpcServerFactoryAutoConfiguration
 org.springframework.grpc.autoconfigure.server.GrpcServerAutoConfiguration
 org.springframework.grpc.autoconfigure.client.GrpcClientAutoConfiguration
+org.springframework.grpc.autoconfigure.server.GrpcServerReflectionAutoConfiguration
+

--- a/spring-grpc-spring-boot-autoconfigure/src/test/java/org/springframework/grpc/autoconfigure/server/GrpcServerReflectionAutoConfigurationTests.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/test/java/org/springframework/grpc/autoconfigure/server/GrpcServerReflectionAutoConfigurationTests.java
@@ -18,16 +18,22 @@ public class GrpcServerReflectionAutoConfigurationTests {
 	}
 
 	@Test
+	void whenReflectionEnabledFlagNotPresentThenCreateDefaultBean() {
+		this.contextRunner()
+				.run((context -> assertThat(context).hasSingleBean(BindableService.class)));
+	}
+
+	@Test
 	void whenReflectionEnabledThenCreateBean() {
 		this.contextRunner()
-			.withPropertyValues("grpc.server.reflection.enabled=true")
+			.withPropertyValues("spring.grpc.server.reflection.enabled=true")
 			.run((context) -> assertThat(context).hasSingleBean(BindableService.class));
 	}
 
 	@Test
 	void whenReflectionDisabledThenSkipBeanCreation() {
 		this.contextRunner()
-			.withPropertyValues("grpc.server.reflection.enabled=false")
+			.withPropertyValues("spring.grpc.server.reflection.enabled=false")
 			.run((context) -> assertThat(context).doesNotHaveBean(BindableService.class));
 	}
 

--- a/spring-grpc-spring-boot-autoconfigure/src/test/java/org/springframework/grpc/autoconfigure/server/GrpcServerReflectionAutoConfigurationTests.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/test/java/org/springframework/grpc/autoconfigure/server/GrpcServerReflectionAutoConfigurationTests.java
@@ -1,0 +1,34 @@
+package org.springframework.grpc.autoconfigure.server;
+
+import io.grpc.BindableService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.grpc.server.lifecycle.GrpcServerLifecycle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GrpcServerReflectionAutoConfigurationTests {
+
+	private ApplicationContextRunner contextRunner() {
+		return new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(GrpcServerReflectionAutoConfiguration.class))
+			.withBean("noopServerLifecylcle", GrpcServerLifecycle.class, Mockito::mock);
+	}
+
+	@Test
+	void whenReflectionEnabledThenCreateBean() {
+		this.contextRunner()
+			.withPropertyValues("grpc.server.reflection.enabled=true")
+			.run((context) -> assertThat(context).hasSingleBean(BindableService.class));
+	}
+
+	@Test
+	void whenReflectionDisabledThenSkipBeanCreation() {
+		this.contextRunner()
+			.withPropertyValues("grpc.server.reflection.enabled=false")
+			.run((context) -> assertThat(context).doesNotHaveBean(BindableService.class));
+	}
+
+}


### PR DESCRIPTION
**… - Add autoconfig for reflection service and friends #26**

- Created new Autoconfiguration for BindableService bean instantiation
- Bean creation triggered based on the presence of configuration property
- Config property: grpc.server.reflection.enabled=true/false