### PR TITLE
Update JavaDocs for grpc-client classes

### DIFF
--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/DefaultGrpcChannelFactory.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/DefaultGrpcChannelFactory.java
@@ -29,6 +29,15 @@ import io.grpc.Grpc;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 
+/**
+ * Default implementation of {@link GrpcChannelFactory} for creating and managing gRPC
+ * channels.
+ * <p>
+ * Implements {@link DisposableBean} to shut down channels when no longer needed
+ *
+ * @author David Syer
+ * @author Chris Bono
+ */
 public class DefaultGrpcChannelFactory implements GrpcChannelFactory, DisposableBean {
 
 	private final Map<String, ManagedChannelBuilder<?>> builders = new ConcurrentHashMap<>();
@@ -71,6 +80,13 @@ public class DefaultGrpcChannelFactory implements GrpcChannelFactory, Disposable
 
 	}
 
+	/**
+	 * Creates a new {@link ManagedChannelBuilder} instance for the given target path and
+	 * credentials.
+	 * @param path the target path for the channel
+	 * @param creds the credentials for the channel
+	 * @return a new {@link ManagedChannelBuilder} for the given path and credentials
+	 */
 	protected ManagedChannelBuilder<?> newChannel(String path, ChannelCredentials creds) {
 		return Grpc.newChannelBuilder(path, creds);
 	}
@@ -82,6 +98,10 @@ public class DefaultGrpcChannelFactory implements GrpcChannelFactory, Disposable
 		}
 	}
 
+	/**
+	 * A {@link ManagedChannelBuilder} wrapper that ensures the created channel is
+	 * disposed of when no longer needed.
+	 */
 	class DisposableChannelBuilder extends ForwardingChannelBuilder2<DisposableChannelBuilder> {
 
 		private final ManagedChannelBuilder<?> delegate;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/GrpcChannelConfigurer.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/GrpcChannelConfigurer.java
@@ -18,9 +18,22 @@ package org.springframework.grpc.client;
 
 import io.grpc.ManagedChannelBuilder;
 
+/**
+ * A functional interface for configuring a {@link ManagedChannelBuilder} for a specific
+ * authority.
+ *
+ * @author Dave Syer
+ * @author Chris Bono
+ * @see ManagedChannelBuilder
+ */
 @FunctionalInterface
 public interface GrpcChannelConfigurer {
 
+	/**
+	 * Configures the given {@link ManagedChannelBuilder} for the specified authority.
+	 * @param authority the target authority for the channel
+	 * @param builder the builder to configure
+	 */
 	void configure(String authority, ManagedChannelBuilder<?> builder);
 
 }

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/GrpcChannelFactory.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/GrpcChannelFactory.java
@@ -18,8 +18,20 @@ package org.springframework.grpc.client;
 
 import io.grpc.ManagedChannelBuilder;
 
+/**
+ * Factory interface for creating {@link ManagedChannelBuilder} instances for a given
+ * authority.
+ *
+ * @author Dave Syer
+ * @see ManagedChannelBuilder
+ */
 public interface GrpcChannelFactory {
 
+	/**
+	 * Creates a {@link ManagedChannelBuilder} for the given authority.
+	 * @param authority the target authority for the channel
+	 * @return a {@link ManagedChannelBuilder} configured for the given authority
+	 */
 	ManagedChannelBuilder<?> createChannel(String authority);
 
 }


### PR DESCRIPTION
I think this will be good for us, since java-doc has already been described for grpc-server classes, so I guess it's worth doing the same for grpc-client classes