### PR TITLE
Support for shutdown grace period in netty clients

### DIFF
--- a/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/client/GrpcClientAutoConfiguration.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/client/GrpcClientAutoConfiguration.java
@@ -48,6 +48,9 @@ public class GrpcClientAutoConfiguration {
 		DefaultGrpcChannelFactory factory = new DefaultGrpcChannelFactory(configurers);
 		factory.setCredentialsProvider(credentials);
 		factory.setVirtualTargets(new NamedChannelVirtualTargets(channels));
+		// Take shutdownGracePeriod from the default channel since it is the same for all
+		// channels
+		factory.setShutdownGracePeriod(channels.getDefaultChannel().getShutdownGracePeriod());
 		return factory;
 	}
 

--- a/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/client/GrpcClientProperties.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/client/GrpcClientProperties.java
@@ -221,6 +221,35 @@ public class GrpcClientProperties implements EnvironmentAware {
 
 		// --------------------------------------------------
 
+		/**
+		 * Maximum time to wait for the client channels to gracefully shutdown. The
+		 * default is 30 seconds.
+		 */
+		@DurationUnit(ChronoUnit.SECONDS)
+		private Duration shutdownGracePeriod = Duration.ofSeconds(30);
+
+		/**
+		 * Gets the shutdown grace period.
+		 * @return The shutdown grace period.
+		 *
+		 * @see #setShutdownGracePeriod(Duration)
+		 */
+		public Duration getShutdownGracePeriod() {
+			return this.shutdownGracePeriod;
+		}
+
+		/**
+		 * The shutdown grace period.
+		 * @param shutdownGracePeriod shutdown grace period will client force shutdown
+		 * channels immediately
+		 *
+		 */
+		public void setShutdownGracePeriod(final Duration shutdownGracePeriod) {
+			this.shutdownGracePeriod = shutdownGracePeriod;
+		}
+
+		// --------------------------------------------------
+
 		@DurationUnit(ChronoUnit.SECONDS)
 		private Duration keepAliveTime;
 
@@ -430,6 +459,9 @@ public class GrpcClientProperties implements EnvironmentAware {
 			}
 			if (this.address == null) {
 				this.address = config.address;
+			}
+			if (this.shutdownGracePeriod == null) {
+				this.shutdownGracePeriod = config.shutdownGracePeriod;
 			}
 			if (this.defaultLoadBalancingPolicy == null) {
 				this.defaultLoadBalancingPolicy = config.defaultLoadBalancingPolicy;


### PR DESCRIPTION
This PR refers to #12

Here we give opportunity to set a specific shutdown grace period in properties. If the customer channel is not fulfilled within this time, it will be shutdowned now.