### PR TITLE
Add autoconfig processor to improve startup time

### DIFF
--- a/spring-grpc-spring-boot-autoconfigure/pom.xml
+++ b/spring-grpc-spring-boot-autoconfigure/pom.xml
@@ -42,7 +42,11 @@
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.grpc</groupId>
 			<artifactId>spring-grpc-core</artifactId>


### PR DESCRIPTION
This commit adds the Spring Boot autoconfiguration processor to generate the `META-INF/spring-autoconfigure-metadata.properties`, which will improve startup time ([details](https://docs.spring.io/spring-boot/reference/features/developing-auto-configuration.html#features.developing-auto-configuration.custom-starter.autoconfigure-module)).

This results in the build generating a file `spring-grpc/spring-grpc-spring-boot-autoconfigure/target/classes/META-INF/spring-autoconfigure-metadata.properties` w/ content:
```properties
org.springframework.grpc.autoconfigure.common.codec.GrpcCodecConfiguration=
org.springframework.grpc.autoconfigure.common.codec.GrpcCodecConfiguration.ConditionalOnClass=io.grpc.Codec
org.springframework.grpc.autoconfigure.server.GrpcServerAutoConfiguration=
org.springframework.grpc.autoconfigure.server.GrpcServerAutoConfiguration.AutoConfigureAfter=org.springframework.grpc.autoconfigure.server.GrpcServerFactoryAutoConfiguration
org.springframework.grpc.autoconfigure.server.GrpcServerAutoConfiguration.ConditionalOnBean=io.grpc.BindableService
org.springframework.grpc.autoconfigure.server.GrpcServerAutoConfiguration.ConditionalOnClass=io.grpc.BindableService
org.springframework.grpc.autoconfigure.server.GrpcServerFactoryAutoConfiguration=
org.springframework.grpc.autoconfigure.server.GrpcServerFactoryAutoConfiguration$GrpcServletConfiguration=
org.springframework.grpc.autoconfigure.server.GrpcServerFactoryAutoConfiguration$GrpcServletConfiguration.ConditionalOnWebApplication=
org.springframework.grpc.autoconfigure.server.GrpcServerFactoryAutoConfiguration.AutoConfigureOrder=-2147483648
org.springframework.grpc.autoconfigure.server.GrpcServerFactoryAutoConfiguration.ConditionalOnBean=io.grpc.BindableService
org.springframework.grpc.autoconfigure.server.GrpcServerFactoryAutoConfiguration.ConditionalOnClass=io.grpc.BindableService
org.springframework.grpc.autoconfigure.server.GrpcServerFactoryConfigurations$NettyServerFactoryConfiguration=
org.springframework.grpc.autoconfigure.server.GrpcServerFactoryConfigurations$NettyServerFactoryConfiguration.ConditionalOnClass=io.grpc.netty.NettyServerBuilder
org.springframework.grpc.autoconfigure.server.GrpcServerFactoryConfigurations$ShadedNettyServerFactoryConfiguration=
org.springframework.grpc.autoconfigure.server.GrpcServerFactoryConfigurations$ShadedNettyServerFactoryConfiguration.ConditionalOnClass=io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder
org.springframework.grpc.autoconfigure.server.GrpcServerObservationAutoConfiguration=
org.springframework.grpc.autoconfigure.server.GrpcServerObservationAutoConfiguration.AutoConfigureAfter=org.springframework.boot.actuate.autoconfigure.observation.ObservationAutoConfiguration
org.springframework.grpc.autoconfigure.server.GrpcServerObservationAutoConfiguration.ConditionalOnBean=io.micrometer.observation.ObservationRegistry
org.springframework.grpc.autoconfigure.server.GrpcServerObservationAutoConfiguration.ConditionalOnClass=io.micrometer.core.instrument.binder.grpc.ObservationGrpcServerInterceptor,io.micrometer.observation.ObservationRegistry
org.springframework.grpc.autoconfigure.server.GrpcServerReflectionAutoConfiguration=
org.springframework.grpc.autoconfigure.server.GrpcServerReflectionAutoConfiguration.AutoConfigureBefore=org.springframework.grpc.autoconfigure.server.GrpcServerFactoryAutoConfiguration
org.springframework.grpc.autoconfigure.server.GrpcServerReflectionAutoConfiguration.ConditionalOnClass=io.grpc.protobuf.services.ProtoReflectionService
```