### PR TITLE
Add server interceptor blending

### DIFF
--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/service/DefaultGrpcServiceConfigurer.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/service/DefaultGrpcServiceConfigurer.java
@@ -76,7 +76,10 @@ public class DefaultGrpcServiceConfigurer implements GrpcServiceConfigurer, Init
 		Arrays.stream(serviceInfo.interceptorNames())
 			.forEachOrdered((interceptorBeanName) -> allInterceptors
 				.add(this.applicationContext.getBean(interceptorBeanName, ServerInterceptor.class)));
-		// TODO handle blend
+		if (serviceInfo.blendWithGlobalInterceptors()) {
+			ApplicationContextBeanLookupUtils.sortBeansIncludingOrderAnnotation(this.applicationContext,
+					ServerInterceptor.class, allInterceptors);
+		}
 		return ServerInterceptors.interceptForward(serviceDef, allInterceptors);
 	}
 

--- a/spring-grpc-core/src/test/java/org/springframework/grpc/server/service/DefaultGrpcServiceConfigurerTests.java
+++ b/spring-grpc-core/src/test/java/org/springframework/grpc/server/service/DefaultGrpcServiceConfigurerTests.java
@@ -25,7 +25,6 @@ import java.util.function.Function;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -256,7 +255,6 @@ class DefaultGrpcServiceConfigurerTests {
 		}
 
 		@SuppressWarnings("unchecked")
-		@Disabled("Needs 'blend interceptors' to be implemented")
 		@Test
 		void whenBlendInterceptorsTrueThenGlobalInterceptorsBlended() {
 			GrpcServiceInfo serviceInfo = new GrpcServiceInfo(

--- a/spring-grpc-docs/src/main/antora/modules/ROOT/pages/server.adoc
+++ b/spring-grpc-docs/src/main/antora/modules/ROOT/pages/server.adoc
@@ -128,6 +128,16 @@ BindableService myService() {
 }
 ----
 
+[[server-interceptor-blending]]
+[TIP]
+====
+When a service is configured with both global and per-service interceptors, the global interceptors are first applied in their sorted order followed by the per-service interceptors in their sorted order.
+
+However, by setting the `blendWithGlobalInterceptors` attribute on the `@GrpcService` annotation to `"true"` you can change this behavior so that the interceptors are all combined and then sorted according to their bean natural ordering (i.e. `@Order`).
+
+You can use this option if you want to add a per-service interceptor between global interceptors.
+====
+
 == Observability
 
 Spring gRPC provides an autoconfigured interceptor that can be used to provide observability to your gRPC services.


### PR DESCRIPTION
This commit implements the `@GprcService(blendWithGlobalInterceptors)` feature. 
This allows global and per-service server interceptors to be combined into a single list and then finally sorted (i.e. blended).