### PR TITLE
Add docs for health feature

### DIFF
--- a/spring-grpc-docs/src/main/antora/modules/ROOT/pages/health.adoc
+++ b/spring-grpc-docs/src/main/antora/modules/ROOT/pages/health.adoc
@@ -1,0 +1,27 @@
+= Health
+
+:spring-boot-docs: https://docs.spring.io/spring-boot/reference
+
+Spring gRPC autoconfigures the standard https://grpc.io/docs/guides/health-checking/[gRPC Health service] for performing health check calls against gRPC servers.
+The health service is registered with the gRPC server and a `HealthStatusManager` bean is provided that can be used to update the health status of your services.
+
+== Actuator Health
+When Spring Boot Actuator is added to your project and the {spring-boot-docs}/actuator/endpoints.html#actuator.endpoints.health[Health endpoint] is available, the framework will automatically periodically update the health status of a configured list of Spring Boot {spring-boot-docs}/actuator/endpoints.html#actuator.endpoints.health.auto-configured-health-indicators[health indicators], including any ({spring-boot-docs}/actuator/endpoints.html#actuator.endpoints.health.writing-custom-health-indicators[custom indicators]).
+By default, the aggregate status of the individual indicators is also used to update the overall server status (`""`).
+
+The following example uses `application.yml` to include the health status of the `db` and `redis` autoconfigured health indicators.
+
+[source,yaml,indent=0,subs="verbatim"]
+----
+spring:
+  grpc:
+    server:
+      health:
+        actuator:
+          health-indicator-paths:
+            - db
+            - redis
+----
+NOTE: The items in the `health-indicator-paths` are the identifiers of the indicator which is typically the name of the indicator bean without the `HealthIndicator` suffix.
+
+You can use the xref:appendix.adoc#common-application-properties["spring.grpc.server.health.*"] application properties to further configure the health feature.

--- a/spring-grpc-docs/src/main/antora/modules/ROOT/pages/server.adoc
+++ b/spring-grpc-docs/src/main/antora/modules/ROOT/pages/server.adoc
@@ -138,6 +138,9 @@ However, by setting the `blendWithGlobalInterceptors` attribute on the `@GrpcSer
 You can use this option if you want to add a per-service interceptor between global interceptors.
 ====
 
+[[health]]
+include::health.adoc[leveloffset=+1]
+
 == Observability
 
 Spring gRPC provides an autoconfigured interceptor that can be used to provide observability to your gRPC services.


### PR DESCRIPTION
This commit adds docs for the server-side portion of the health feature.

See #56

<img width="1099" alt="Screenshot 2024-11-26 at 10 53 28" src="https://github.com/user-attachments/assets/d9d76d1b-b31a-45aa-95c4-6c678d3f294f">

