### PR TITLE
[WIP] Add client interceptors to channel factory

### DIFF
--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/ClientInterceptorsConfigurer.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/ClientInterceptorsConfigurer.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * */
+
+package org.springframework.grpc.client;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.grpc.internal.ApplicationContextBeanLookupUtils;
+
+import io.grpc.ClientInterceptor;
+import io.grpc.ManagedChannelBuilder;
+
+/**
+ * Configure a {@link ManagedChannelBuilder} with client interceptors.
+ *
+ * @author Chris Bono
+ */
+public class ClientInterceptorsConfigurer implements InitializingBean {
+
+	private final ApplicationContext applicationContext;
+
+	private List<ClientInterceptor> globalInterceptors;
+
+	public ClientInterceptorsConfigurer(ApplicationContext applicationContext) {
+		this.applicationContext = applicationContext;
+	}
+
+	/**
+	 * Configure a {@link ManagedChannelBuilder} with client interceptors.
+	 * @param authority the target authority for the channel
+	 * @param builder the builder to configure
+	 * @param interceptors the non-null list of interceptors to be applied to the channel
+	 * @param mergeWithGlobalInterceptors whether the provided interceptors should be
+	 * blended with the global interceptors.
+	 */
+	protected void configureInterceptors(String authority, ManagedChannelBuilder<?> builder,
+			List<ClientInterceptor> interceptors, boolean mergeWithGlobalInterceptors) {
+		// Add global interceptors first
+		List<ClientInterceptor> allInterceptors = new ArrayList<>(this.globalInterceptors);
+		// Add specific interceptors
+		allInterceptors.addAll(interceptors);
+		if (mergeWithGlobalInterceptors) {
+			ApplicationContextBeanLookupUtils.sortBeansIncludingOrderAnnotation(this.applicationContext,
+					ClientInterceptor.class, allInterceptors);
+		}
+		Collections.reverse(allInterceptors);
+		builder.intercept(allInterceptors);
+	}
+
+	@Override
+	public void afterPropertiesSet() {
+		this.globalInterceptors = findGlobalInterceptors();
+	}
+
+	private List<ClientInterceptor> findGlobalInterceptors() {
+		return ApplicationContextBeanLookupUtils.getBeansWithAnnotation(this.applicationContext,
+				ClientInterceptor.class, GlobalClientInterceptor.class);
+	}
+
+}

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/GlobalClientInterceptor.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/GlobalClientInterceptor.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Partial copy from net.devh:grpc-spring-boot-starter.
+ */
+
+package org.springframework.grpc.client;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.core.annotation.Order;
+
+import io.grpc.ClientInterceptor;
+
+/**
+ * Annotation that can be specified on a gRPC {@link ClientInterceptor} bean which will
+ * result in the interceptor being applied globally to channels.
+ * <p>
+ * The bean interceptor {@link Order} will be respected.
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ * @author Chris Bono
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface GlobalClientInterceptor {
+
+}

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/GrpcChannelFactory.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/GrpcChannelFactory.java
@@ -16,6 +16,9 @@
 
 package org.springframework.grpc.client;
 
+import java.util.List;
+
+import io.grpc.ClientInterceptor;
 import io.grpc.ManagedChannelBuilder;
 
 /**
@@ -33,5 +36,17 @@ public interface GrpcChannelFactory {
 	 * @return a {@link ManagedChannelBuilder} configured for the given authority
 	 */
 	ManagedChannelBuilder<?> createChannel(String authority);
+
+	/**
+	 * Creates a {@link ManagedChannelBuilder} for the given authority and the provided
+	 * client interceptors.
+	 * @param authority the target authority for the channel
+	 * @param interceptors the non-null list of interceptors to be applied to the channel
+	 * @param mergeWithGlobalInterceptors whether the provided interceptors should be
+	 * blended with the global interceptors.
+	 * @return a channel builder conifgured with the provided values
+	 */
+	ManagedChannelBuilder<?> createChannel(String authority, List<ClientInterceptor> interceptors,
+			boolean mergeWithGlobalInterceptors);
 
 }

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/internal/ApplicationContextBeanLookupUtils.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/internal/ApplicationContextBeanLookupUtils.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.grpc.server.service;
+package org.springframework.grpc.internal;
 
 import java.lang.annotation.Annotation;
 import java.util.LinkedHashMap;
@@ -29,10 +29,13 @@ import org.springframework.util.Assert;
 /**
  * Convenience methods performing bean lookups that are not currently provided by the
  * standard Spring facilities.
+ * <p>
+ * <b>NOTE:</b> This is considered an internal non-public API despite its public method
+ * accessors.
  *
  * @author Chris Bono
  */
-final class ApplicationContextBeanLookupUtils {
+public final class ApplicationContextBeanLookupUtils {
 
 	private ApplicationContextBeanLookupUtils() {
 	}
@@ -56,7 +59,7 @@ final class ApplicationContextBeanLookupUtils {
 	 * @return a map of matching bean instances with the annotation instance (or null)
 	 * ordered according to their {@link Order} with annotation
 	 */
-	static <B, A extends Annotation> LinkedHashMap<B, A> getOrderedBeansWithAnnotation(
+	public static <B, A extends Annotation> LinkedHashMap<B, A> getOrderedBeansWithAnnotation(
 			ApplicationContext applicationContext, Class<B> beanType, Class<A> annotationType) {
 		Assert.notNull(applicationContext, () -> "applicationContext must not be null");
 		var annotatedBeanNamesToBeans = applicationContext.getBeansWithAnnotation(annotationType);
@@ -87,7 +90,7 @@ final class ApplicationContextBeanLookupUtils {
 	 * @return a list of the matching beans ordered according to their {@link Order}
 	 * annotation
 	 */
-	static <B, A extends Annotation> List<B> getBeansWithAnnotation(ApplicationContext applicationContext,
+	public static <B, A extends Annotation> List<B> getBeansWithAnnotation(ApplicationContext applicationContext,
 			Class<B> beanType, Class<A> annotationType) {
 		Assert.notNull(applicationContext, () -> "applicationContext must not be null");
 		var nameToBeanMap = applicationContext.getBeansWithAnnotation(annotationType);
@@ -104,7 +107,7 @@ final class ApplicationContextBeanLookupUtils {
 	 * @param beanType the type of beans in the list
 	 * @param beans the list of beans to sort
 	 */
-	static void sortBeansIncludingOrderAnnotation(ApplicationContext applicationContext, Class<?> beanType,
+	public static void sortBeansIncludingOrderAnnotation(ApplicationContext applicationContext, Class<?> beanType,
 			List<?> beans) {
 		var beanToNameMap = new LinkedHashMap<Object, String>();
 		applicationContext.getBeansOfType(beanType).forEach((name, bean) -> beanToNameMap.put(bean, name));

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/service/DefaultGrpcServiceConfigurer.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/service/DefaultGrpcServiceConfigurer.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ApplicationContext;
+import org.springframework.grpc.internal.ApplicationContextBeanLookupUtils;
 import org.springframework.grpc.server.GlobalServerInterceptor;
 import org.springframework.lang.Nullable;
 

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/service/DefaultGrpcServiceDiscoverer.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/service/DefaultGrpcServiceDiscoverer.java
@@ -19,6 +19,7 @@ package org.springframework.grpc.server.service;
 import java.util.List;
 
 import org.springframework.context.ApplicationContext;
+import org.springframework.grpc.internal.ApplicationContextBeanLookupUtils;
 import org.springframework.lang.Nullable;
 
 import io.grpc.BindableService;

--- a/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/client/GrpcClientAutoConfiguration.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/client/GrpcClientAutoConfiguration.java
@@ -23,12 +23,14 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.ssl.SslBundles;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.grpc.autoconfigure.client.GrpcClientProperties.NamedChannel;
 import org.springframework.grpc.autoconfigure.common.codec.GrpcCodecConfiguration;
 import org.springframework.grpc.client.ChannelCredentialsProvider;
+import org.springframework.grpc.client.ClientInterceptorsConfigurer;
 import org.springframework.grpc.client.DefaultGrpcChannelFactory;
 import org.springframework.grpc.client.GrpcChannelConfigurer;
 import org.springframework.grpc.client.GrpcChannelFactory;
@@ -43,10 +45,17 @@ import io.grpc.DecompressorRegistry;
 public class GrpcClientAutoConfiguration {
 
 	@Bean
+	@ConditionalOnMissingBean
+	ClientInterceptorsConfigurer clientInterceptorsConfigurer(ApplicationContext applicationContext) {
+		return new ClientInterceptorsConfigurer(applicationContext);
+	}
+
+	@Bean
 	@ConditionalOnMissingBean(GrpcChannelFactory.class)
-	public DefaultGrpcChannelFactory defaultGrpcChannelFactory(final List<GrpcChannelConfigurer> configurers,
-			ChannelCredentialsProvider credentials, GrpcClientProperties channels, SslBundles ignored) {
-		DefaultGrpcChannelFactory factory = new DefaultGrpcChannelFactory(configurers);
+	public DefaultGrpcChannelFactory defaultGrpcChannelFactory(List<GrpcChannelConfigurer> configurers,
+			ClientInterceptorsConfigurer interceptorsConfigurer, ChannelCredentialsProvider credentials,
+			GrpcClientProperties channels, SslBundles ignored) {
+		DefaultGrpcChannelFactory factory = new DefaultGrpcChannelFactory(configurers, interceptorsConfigurer);
 		factory.setCredentialsProvider(credentials);
 		factory.setVirtualTargets(new NamedChannelVirtualTargets(channels));
 		return factory;

--- a/spring-grpc-test/src/main/java/org/springframework/grpc/test/InProcessGrpcChannelFactory.java
+++ b/spring-grpc-test/src/main/java/org/springframework/grpc/test/InProcessGrpcChannelFactory.java
@@ -15,6 +15,9 @@
  */
 package org.springframework.grpc.test;
 
+import java.util.List;
+
+import org.springframework.grpc.client.ClientInterceptorsConfigurer;
 import org.springframework.grpc.client.DefaultGrpcChannelFactory;
 
 import io.grpc.ChannelCredentials;
@@ -23,8 +26,12 @@ import io.grpc.inprocess.InProcessChannelBuilder;
 
 public class InProcessGrpcChannelFactory extends DefaultGrpcChannelFactory {
 
+	public InProcessGrpcChannelFactory(ClientInterceptorsConfigurer interceptorsConfigurer) {
+		super(List.of(), interceptorsConfigurer);
+	}
+
 	@Override
-	protected ManagedChannelBuilder<?> newChannel(String path, ChannelCredentials creds) {
+	protected ManagedChannelBuilder<?> newChannelBuilder(String path, ChannelCredentials creds) {
 		return InProcessChannelBuilder.forName(path);
 	}
 


### PR DESCRIPTION
> [!NOTE]
> This is a rough 1st pass to get buy-in before moving forward further

**Commit 1:** just moves the bean lookup util to the internal package so it can be shared w/ client package.

This commit adds support for global and channel-specific client interceptors.

See #52 