### PR TITLE
Prepare for client interceptors

### DIFF
--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/GrpcChannelBuilderCustomizer.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/GrpcChannelBuilderCustomizer.java
@@ -19,21 +19,21 @@ package org.springframework.grpc.client;
 import io.grpc.ManagedChannelBuilder;
 
 /**
- * A functional interface for configuring a {@link ManagedChannelBuilder} for a specific
- * authority.
+ * Callback interface that can be used to customize a {@link ManagedChannelBuilder} for a
+ * specific authority.
  *
  * @author Dave Syer
  * @author Chris Bono
- * @see ManagedChannelBuilder
  */
 @FunctionalInterface
-public interface GrpcChannelConfigurer {
+public interface GrpcChannelBuilderCustomizer {
 
 	/**
-	 * Configures the given {@link ManagedChannelBuilder} for the specified authority.
+	 * Callback to customize a {@link ManagedChannelBuilder} instance for a specified
+	 * authority.
 	 * @param authority the target authority for the channel
-	 * @param builder the builder to configure
+	 * @param builder the builder to customize
 	 */
-	void configure(String authority, ManagedChannelBuilder<?> builder);
+	void customize(String authority, ManagedChannelBuilder<?> builder);
 
 }

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/internal/ApplicationContextBeanLookupUtils.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/internal/ApplicationContextBeanLookupUtils.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.grpc.server.service;
+package org.springframework.grpc.internal;
 
 import java.lang.annotation.Annotation;
 import java.util.LinkedHashMap;
@@ -29,10 +29,13 @@ import org.springframework.util.Assert;
 /**
  * Convenience methods performing bean lookups that are not currently provided by the
  * standard Spring facilities.
+ * <p>
+ * <b>NOTE:</b> This is considered an internal non-public API despite its public method
+ * accessors.
  *
  * @author Chris Bono
  */
-final class ApplicationContextBeanLookupUtils {
+public final class ApplicationContextBeanLookupUtils {
 
 	private ApplicationContextBeanLookupUtils() {
 	}
@@ -56,7 +59,7 @@ final class ApplicationContextBeanLookupUtils {
 	 * @return a map of matching bean instances with the annotation instance (or null)
 	 * ordered according to their {@link Order} with annotation
 	 */
-	static <B, A extends Annotation> LinkedHashMap<B, A> getOrderedBeansWithAnnotation(
+	public static <B, A extends Annotation> LinkedHashMap<B, A> getOrderedBeansWithAnnotation(
 			ApplicationContext applicationContext, Class<B> beanType, Class<A> annotationType) {
 		Assert.notNull(applicationContext, () -> "applicationContext must not be null");
 		var annotatedBeanNamesToBeans = applicationContext.getBeansWithAnnotation(annotationType);
@@ -87,7 +90,7 @@ final class ApplicationContextBeanLookupUtils {
 	 * @return a list of the matching beans ordered according to their {@link Order}
 	 * annotation
 	 */
-	static <B, A extends Annotation> List<B> getBeansWithAnnotation(ApplicationContext applicationContext,
+	public static <B, A extends Annotation> List<B> getBeansWithAnnotation(ApplicationContext applicationContext,
 			Class<B> beanType, Class<A> annotationType) {
 		Assert.notNull(applicationContext, () -> "applicationContext must not be null");
 		var nameToBeanMap = applicationContext.getBeansWithAnnotation(annotationType);
@@ -104,7 +107,7 @@ final class ApplicationContextBeanLookupUtils {
 	 * @param beanType the type of beans in the list
 	 * @param beans the list of beans to sort
 	 */
-	static void sortBeansIncludingOrderAnnotation(ApplicationContext applicationContext, Class<?> beanType,
+	public static void sortBeansIncludingOrderAnnotation(ApplicationContext applicationContext, Class<?> beanType,
 			List<?> beans) {
 		var beanToNameMap = new LinkedHashMap<Object, String>();
 		applicationContext.getBeansOfType(beanType).forEach((name, bean) -> beanToNameMap.put(bean, name));

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/service/DefaultGrpcServiceConfigurer.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/service/DefaultGrpcServiceConfigurer.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ApplicationContext;
+import org.springframework.grpc.internal.ApplicationContextBeanLookupUtils;
 import org.springframework.grpc.server.GlobalServerInterceptor;
 import org.springframework.lang.Nullable;
 

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/service/DefaultGrpcServiceDiscoverer.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/service/DefaultGrpcServiceDiscoverer.java
@@ -19,6 +19,7 @@ package org.springframework.grpc.server.service;
 import java.util.List;
 
 import org.springframework.context.ApplicationContext;
+import org.springframework.grpc.internal.ApplicationContextBeanLookupUtils;
 import org.springframework.lang.Nullable;
 
 import io.grpc.BindableService;

--- a/spring-grpc-docs/src/main/antora/modules/ROOT/nav.adoc
+++ b/spring-grpc-docs/src/main/antora/modules/ROOT/nav.adoc
@@ -1,4 +1,5 @@
 * xref:index.adoc[Overview]
+* xref:whats-new.adoc[What's new?]
 * xref:getting-started.adoc[Getting Started]
 * xref:server.adoc[GRPC Server]
 * xref:client.adoc[GRPC Clients]

--- a/spring-grpc-docs/src/main/antora/modules/ROOT/pages/client.adoc
+++ b/spring-grpc-docs/src/main/antora/modules/ROOT/pages/client.adoc
@@ -82,7 +82,7 @@ spring.grpc.client.channels.local.address=0.0.0.0:9090
 
 There is a default named channel (named "default") that you can configure in the same way, and then it will be used by default if there is no channel with the name specified in the channel creation.
 
-Beans of type `GrpcChannelConfigurer` can be used to customize the `ChannelBuilder` before the channel is built.
+Beans of type `GrpcChannelBuilderCustomizer` can be used to customize the `ChannelBuilder` before the channel is built.
 This can be useful for setting up security, for example.
 
 == The Local Server Port

--- a/spring-grpc-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-grpc-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -1,0 +1,13 @@
+= What's new?
+
+[[what-s-new-in-0-3-0-since-0-2-0]]
+== What's New in 0.3.0 Since 0.2.0
+:page-section-summary-toc: 1
+
+This section covers the changes made from version 0.2.0 to version 0.3.0.
+
+
+=== Breaking Changes
+
+==== GrpcChannelConfigurer renamed
+The `GrpcChannelConfigurer` has been renamed to `GrpcChannelBuilderCustomizer` to more accurately represent its purpose and be consistent with the server-side terminology.

--- a/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/client/ClientPropertiesChannelBuilderCustomizer.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/client/ClientPropertiesChannelBuilderCustomizer.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.grpc.autoconfigure.client;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import org.springframework.boot.context.properties.PropertyMapper;
+import org.springframework.grpc.autoconfigure.client.GrpcClientProperties.NamedChannel;
+import org.springframework.grpc.client.GrpcChannelBuilderCustomizer;
+import org.springframework.util.unit.DataSize;
+
+import io.grpc.ManagedChannelBuilder;
+
+/**
+ * A {@link GrpcChannelBuilderCustomizer} that maps {@link GrpcClientProperties client
+ * properties} to a channel builder.
+ *
+ * @author David Syer
+ * @author Chris Bono
+ */
+class ClientPropertiesChannelBuilderCustomizer implements GrpcChannelBuilderCustomizer {
+
+	private final GrpcClientProperties properties;
+
+	ClientPropertiesChannelBuilderCustomizer(GrpcClientProperties properties) {
+		this.properties = properties;
+	}
+
+	@Override
+	public void customize(String authority, ManagedChannelBuilder<?> builder) {
+		NamedChannel channel = this.properties.getChannels().get(authority);
+		if (channel == null) {
+			return;
+		}
+		PropertyMapper mapper = PropertyMapper.get().alwaysApplyingWhenNonNull();
+		mapper.from(channel.getUserAgent()).to(builder::userAgent);
+		mapper.from(channel.getDefaultLoadBalancingPolicy()).to(builder::defaultLoadBalancingPolicy);
+		mapper.from(channel.getMaxInboundMessageSize()).asInt(DataSize::toBytes).to(builder::maxInboundMessageSize);
+		mapper.from(channel.getMaxInboundMetadataSize()).asInt(DataSize::toBytes).to(builder::maxInboundMessageSize);
+		mapper.from(channel.getKeepAliveTime()).to(durationProperty(builder::keepAliveTime));
+		mapper.from(channel.getKeepAliveTimeout()).to(durationProperty(builder::keepAliveTimeout));
+		mapper.from(channel.getIdleTimeout()).to(durationProperty(builder::idleTimeout));
+		mapper.from(channel.isKeepAliveWithoutCalls()).to(builder::keepAliveWithoutCalls);
+		if (channel.getHealth().isEnabled()) {
+			String serviceNameToCheck = channel.getHealth().getServiceName() != null
+					? channel.getHealth().getServiceName() : "";
+			Map<String, ?> healthCheckConfig = Map.of("healthCheckConfig", Map.of("serviceName", serviceNameToCheck));
+			builder.defaultServiceConfig(healthCheckConfig);
+		}
+	}
+
+	Consumer<Duration> durationProperty(BiConsumer<Long, TimeUnit> setter) {
+		return (duration) -> setter.accept(duration.toNanos(), TimeUnit.NANOSECONDS);
+	}
+
+}

--- a/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/client/GrpcClientAutoConfiguration.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/client/GrpcClientAutoConfiguration.java
@@ -30,7 +30,7 @@ import org.springframework.grpc.autoconfigure.client.GrpcClientProperties.NamedC
 import org.springframework.grpc.autoconfigure.common.codec.GrpcCodecConfiguration;
 import org.springframework.grpc.client.ChannelCredentialsProvider;
 import org.springframework.grpc.client.DefaultGrpcChannelFactory;
-import org.springframework.grpc.client.GrpcChannelConfigurer;
+import org.springframework.grpc.client.GrpcChannelBuilderCustomizer;
 import org.springframework.grpc.client.GrpcChannelFactory;
 import org.springframework.grpc.client.VirtualTargets;
 
@@ -44,9 +44,9 @@ public class GrpcClientAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean(GrpcChannelFactory.class)
-	public DefaultGrpcChannelFactory defaultGrpcChannelFactory(final List<GrpcChannelConfigurer> configurers,
+	public DefaultGrpcChannelFactory defaultGrpcChannelFactory(List<GrpcChannelBuilderCustomizer> customizers,
 			ChannelCredentialsProvider credentials, GrpcClientProperties channels, SslBundles ignored) {
-		DefaultGrpcChannelFactory factory = new DefaultGrpcChannelFactory(configurers);
+		DefaultGrpcChannelFactory factory = new DefaultGrpcChannelFactory(customizers);
 		factory.setCredentialsProvider(credentials);
 		factory.setVirtualTargets(new NamedChannelVirtualTargets(channels));
 		return factory;
@@ -60,7 +60,7 @@ public class GrpcClientAutoConfiguration {
 	}
 
 	@Bean
-	public GrpcChannelConfigurer baseGrpcChannelConfigurer(GrpcClientProperties channels) {
+	public GrpcChannelBuilderCustomizer baseGrpcChannelBuilderCustomizer(GrpcClientProperties channels) {
 		return (authority, builder) -> {
 			for (String name : channels.getChannels().keySet()) {
 				if (authority.equals(name)) {
@@ -101,13 +101,13 @@ public class GrpcClientAutoConfiguration {
 
 	@ConditionalOnBean(CompressorRegistry.class)
 	@Bean
-	GrpcChannelConfigurer compressionClientConfigurer(CompressorRegistry registry) {
+	GrpcChannelBuilderCustomizer compressionClientCustomizer(CompressorRegistry registry) {
 		return (name, builder) -> builder.compressorRegistry(registry);
 	}
 
 	@ConditionalOnBean(DecompressorRegistry.class)
 	@Bean
-	GrpcChannelConfigurer decompressionClientConfigurer(DecompressorRegistry registry) {
+	GrpcChannelBuilderCustomizer decompressionClientCustomizer(DecompressorRegistry registry) {
 		return (name, builder) -> builder.decompressorRegistry(registry);
 	}
 

--- a/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/client/GrpcClientAutoConfiguration.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/client/GrpcClientAutoConfiguration.java
@@ -16,8 +16,6 @@
 package org.springframework.grpc.autoconfigure.client;
 
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -60,43 +58,8 @@ public class GrpcClientAutoConfiguration {
 	}
 
 	@Bean
-	public GrpcChannelBuilderCustomizer baseGrpcChannelBuilderCustomizer(GrpcClientProperties channels) {
-		return (authority, builder) -> {
-			for (String name : channels.getChannels().keySet()) {
-				if (authority.equals(name)) {
-					NamedChannel channel = channels.getChannels().get(name);
-					if (channel.getUserAgent() != null) {
-						builder.userAgent(channel.getUserAgent());
-					}
-					if (channel.getDefaultLoadBalancingPolicy() != null) {
-						builder.defaultLoadBalancingPolicy(channel.getDefaultLoadBalancingPolicy());
-					}
-					if (channel.getHealth().isEnabled()) {
-						String serviceNameToCheck = channel.getHealth().getServiceName() != null
-								? channel.getHealth().getServiceName() : "";
-						Map<String, ?> healthCheckConfig = Map.of("healthCheckConfig",
-								Map.of("serviceName", serviceNameToCheck));
-						builder.defaultServiceConfig(healthCheckConfig);
-					}
-					if (channel.getMaxInboundMessageSize() != null) {
-						builder.maxInboundMessageSize((int) channel.getMaxInboundMessageSize().toBytes());
-					}
-					if (channel.getMaxInboundMetadataSize() != null) {
-						builder.maxInboundMetadataSize((int) channel.getMaxInboundMetadataSize().toBytes());
-					}
-					if (channel.getKeepAliveTime() != null) {
-						builder.keepAliveTime(channel.getKeepAliveTime().toNanos(), TimeUnit.NANOSECONDS);
-					}
-					if (channel.getKeepAliveTimeout() != null) {
-						builder.keepAliveTimeout(channel.getKeepAliveTimeout().toNanos(), TimeUnit.NANOSECONDS);
-					}
-					builder.keepAliveWithoutCalls(channel.isKeepAliveWithoutCalls());
-					if (channel.getIdleTimeout() != null) {
-						builder.idleTimeout(channel.getIdleTimeout().toNanos(), TimeUnit.NANOSECONDS);
-					}
-				}
-			}
-		};
+	public GrpcChannelBuilderCustomizer clientPropertiesChannelCustomizer(GrpcClientProperties properties) {
+		return new ClientPropertiesChannelBuilderCustomizer(properties);
 	}
 
 	@ConditionalOnBean(CompressorRegistry.class)

--- a/spring-grpc-spring-boot-autoconfigure/src/test/java/org/springframework/grpc/autoconfigure/client/GrpcClientAutoConfigurationTests.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/test/java/org/springframework/grpc/autoconfigure/client/GrpcClientAutoConfigurationTests.java
@@ -35,7 +35,7 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.grpc.autoconfigure.client.GrpcClientAutoConfiguration.NamedChannelVirtualTargets;
 import org.springframework.grpc.client.ChannelCredentialsProvider;
 import org.springframework.grpc.client.DefaultGrpcChannelFactory;
-import org.springframework.grpc.client.GrpcChannelConfigurer;
+import org.springframework.grpc.client.GrpcChannelBuilderCustomizer;
 import org.springframework.grpc.client.GrpcChannelFactory;
 
 import io.grpc.Codec;
@@ -91,27 +91,30 @@ class GrpcClientAutoConfigurationTests {
 	}
 
 	@Test
-	void baseChannelConfigurerAutoConfiguredWithHealthAsExpected() {
+	void baseChannelCustomizerAutoConfiguredWithHealthAsExpected() {
 		this.contextRunner()
 			.withPropertyValues("spring.grpc.client.channels.test.health.enabled=true",
 					"spring.grpc.client.channels.test.health.service-name=my-service")
 			.run((context) -> {
-				assertThat(context).getBean("baseGrpcChannelConfigurer", GrpcChannelConfigurer.class).isNotNull();
-				var configurer = context.getBean("baseGrpcChannelConfigurer", GrpcChannelConfigurer.class);
+				assertThat(context).getBean("baseGrpcChannelBuilderCustomizer", GrpcChannelBuilderCustomizer.class)
+					.isNotNull();
+				var customizer = context.getBean("baseGrpcChannelBuilderCustomizer",
+						GrpcChannelBuilderCustomizer.class);
 				ManagedChannelBuilder<?> builder = Mockito.mock();
-				configurer.configure("test", builder);
+				customizer.customize("test", builder);
 				Map<String, ?> healthCheckConfig = Map.of("healthCheckConfig", Map.of("serviceName", "my-service"));
 				verify(builder).defaultServiceConfig(healthCheckConfig);
 			});
 	}
 
 	@Test
-	void baseChannelConfigurerAutoConfiguredWithoutHealthAsExpected() {
+	void baseChannelCustomizerAutoConfiguredWithoutHealthAsExpected() {
 		this.contextRunner().run((context) -> {
-			assertThat(context).getBean("baseGrpcChannelConfigurer", GrpcChannelConfigurer.class).isNotNull();
-			var configurer = context.getBean("baseGrpcChannelConfigurer", GrpcChannelConfigurer.class);
+			assertThat(context).getBean("baseGrpcChannelBuilderCustomizer", GrpcChannelBuilderCustomizer.class)
+				.isNotNull();
+			var customizer = context.getBean("baseGrpcChannelBuilderCustomizer", GrpcChannelBuilderCustomizer.class);
 			ManagedChannelBuilder<?> builder = Mockito.mock();
-			configurer.configure("test", builder);
+			customizer.customize("test", builder);
 			verify(builder, never()).defaultServiceConfig(anyMap());
 		});
 	}
@@ -122,18 +125,19 @@ class GrpcClientAutoConfigurationTests {
 		// registry
 		this.contextRunner()
 			.withClassLoader(new FilteredClassLoader(Codec.class))
-			.run((context) -> assertThat(context).getBean("compressionClientConfigurer", GrpcChannelConfigurer.class)
+			.run((context) -> assertThat(context)
+				.getBean("compressionClientCustomizer", GrpcChannelBuilderCustomizer.class)
 				.isNull());
 	}
 
 	@Test
-	void compressionConfigurerAutoConfiguredAsExpected() {
+	void compressionCustomizerAutoConfiguredAsExpected() {
 		this.contextRunner().run((context) -> {
-			assertThat(context).getBean("compressionClientConfigurer", GrpcChannelConfigurer.class).isNotNull();
-			var configurer = context.getBean("compressionClientConfigurer", GrpcChannelConfigurer.class);
+			assertThat(context).getBean("compressionClientCustomizer", GrpcChannelBuilderCustomizer.class).isNotNull();
+			var customizer = context.getBean("compressionClientCustomizer", GrpcChannelBuilderCustomizer.class);
 			var compressorRegistry = context.getBean(CompressorRegistry.class);
 			ManagedChannelBuilder<?> builder = Mockito.mock();
-			configurer.configure("testChannel", builder);
+			customizer.customize("testChannel", builder);
 			verify(builder).compressorRegistry(compressorRegistry);
 		});
 	}
@@ -144,18 +148,20 @@ class GrpcClientAutoConfigurationTests {
 		// registry
 		this.contextRunner()
 			.withClassLoader(new FilteredClassLoader(Codec.class))
-			.run((context) -> assertThat(context).getBean("decompressionClientConfigurer", GrpcChannelConfigurer.class)
+			.run((context) -> assertThat(context)
+				.getBean("decompressionClientCustomizer", GrpcChannelBuilderCustomizer.class)
 				.isNull());
 	}
 
 	@Test
-	void decompressionConfigurerAutoConfiguredAsExpected() {
+	void decompressionCustomizerAutoConfiguredAsExpected() {
 		this.contextRunner().run((context) -> {
-			assertThat(context).getBean("decompressionClientConfigurer", GrpcChannelConfigurer.class).isNotNull();
-			var configurer = context.getBean("decompressionClientConfigurer", GrpcChannelConfigurer.class);
+			assertThat(context).getBean("decompressionClientCustomizer", GrpcChannelBuilderCustomizer.class)
+				.isNotNull();
+			var customizer = context.getBean("decompressionClientCustomizer", GrpcChannelBuilderCustomizer.class);
 			var decompressorRegistry = context.getBean(DecompressorRegistry.class);
 			ManagedChannelBuilder<?> builder = Mockito.mock();
-			configurer.configure("testChannel", builder);
+			customizer.customize("testChannel", builder);
 			verify(builder).decompressorRegistry(decompressorRegistry);
 		});
 	}

--- a/spring-grpc-spring-boot-autoconfigure/src/test/java/org/springframework/grpc/autoconfigure/client/GrpcClientAutoConfigurationTests.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/test/java/org/springframework/grpc/autoconfigure/client/GrpcClientAutoConfigurationTests.java
@@ -91,14 +91,14 @@ class GrpcClientAutoConfigurationTests {
 	}
 
 	@Test
-	void baseChannelCustomizerAutoConfiguredWithHealthAsExpected() {
+	void clientPropertiesChannelCustomizerAutoConfiguredWithHealthAsExpected() {
 		this.contextRunner()
 			.withPropertyValues("spring.grpc.client.channels.test.health.enabled=true",
 					"spring.grpc.client.channels.test.health.service-name=my-service")
 			.run((context) -> {
-				assertThat(context).getBean("baseGrpcChannelBuilderCustomizer", GrpcChannelBuilderCustomizer.class)
+				assertThat(context).getBean("clientPropertiesChannelCustomizer", GrpcChannelBuilderCustomizer.class)
 					.isNotNull();
-				var customizer = context.getBean("baseGrpcChannelBuilderCustomizer",
+				var customizer = context.getBean("clientPropertiesChannelCustomizer",
 						GrpcChannelBuilderCustomizer.class);
 				ManagedChannelBuilder<?> builder = Mockito.mock();
 				customizer.customize("test", builder);
@@ -108,11 +108,11 @@ class GrpcClientAutoConfigurationTests {
 	}
 
 	@Test
-	void baseChannelCustomizerAutoConfiguredWithoutHealthAsExpected() {
+	void clientPropertiesChannelCustomizerAutoConfiguredWithoutHealthAsExpected() {
 		this.contextRunner().run((context) -> {
-			assertThat(context).getBean("baseGrpcChannelBuilderCustomizer", GrpcChannelBuilderCustomizer.class)
+			assertThat(context).getBean("clientPropertiesChannelCustomizer", GrpcChannelBuilderCustomizer.class)
 				.isNotNull();
-			var customizer = context.getBean("baseGrpcChannelBuilderCustomizer", GrpcChannelBuilderCustomizer.class);
+			var customizer = context.getBean("clientPropertiesChannelCustomizer", GrpcChannelBuilderCustomizer.class);
 			ManagedChannelBuilder<?> builder = Mockito.mock();
 			customizer.customize("test", builder);
 			verify(builder, never()).defaultServiceConfig(anyMap());


### PR DESCRIPTION
This PR prepares for adding client interceptors as follows.

> [!NOTE]
> The commits are separate by design - please do not squash during merge

## Commit 1: Move bean lookup utils into common package
This commit moves the `ApplicationContextBeanLookupUtils` into the
'internal' package and opens up its method to public visibility so
that it can be shared amongst framework components.

## Commit 2: Rename client configurer to customizer
This commit renames the `GrpcChannelConfigurer` to `GrpcChannelBuilderCustomizer`
to more accurately represent its purpose and for consistency with the
server-side terminology.

Additionally, a new `What's new?` doc is added to list breaking changes between
versions.

## Commit 3: Move client properties customizer to upper level
This commit moves the client properties customizer from an inner class
to its own top-level class to make it easier to test and for readability.

See #52 