### PR TITLE
Split client interceptor autoconfiguration

### DIFF
--- a/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/client/ClientInterceptorsConfiguration.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/client/ClientInterceptorsConfiguration.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.grpc.autoconfigure.client;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.grpc.client.ClientInterceptorsConfigurer;
+
+/**
+ * Configuration for {@link ClientInterceptorsConfigurer}.
+ *
+ * @author Chris Bono
+ */
+public class ClientInterceptorsConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean
+	ClientInterceptorsConfigurer clientInterceptorsConfigurer(ApplicationContext applicationContext) {
+		return new ClientInterceptorsConfigurer(applicationContext);
+	}
+
+}

--- a/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/client/GrpcClientAutoConfiguration.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/client/GrpcClientAutoConfiguration.java
@@ -21,7 +21,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.ssl.SslBundles;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -39,18 +38,12 @@ import io.grpc.DecompressorRegistry;
 
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(GrpcClientProperties.class)
-@Import(GrpcCodecConfiguration.class)
+@Import({ GrpcCodecConfiguration.class, ClientInterceptorsConfiguration.class })
 public class GrpcClientAutoConfiguration {
 
 	@Bean
-	@ConditionalOnMissingBean
-	ClientInterceptorsConfigurer clientInterceptorsConfigurer(ApplicationContext applicationContext) {
-		return new ClientInterceptorsConfigurer(applicationContext);
-	}
-
-	@Bean
 	@ConditionalOnMissingBean(GrpcChannelFactory.class)
-	public DefaultGrpcChannelFactory defaultGrpcChannelFactory(List<GrpcChannelBuilderCustomizer> customizers,
+	DefaultGrpcChannelFactory defaultGrpcChannelFactory(List<GrpcChannelBuilderCustomizer> customizers,
 			ClientInterceptorsConfigurer interceptorsConfigurer, ChannelCredentialsProvider credentials,
 			GrpcClientProperties channels, SslBundles ignored) {
 		DefaultGrpcChannelFactory factory = new DefaultGrpcChannelFactory(customizers, interceptorsConfigurer);
@@ -61,13 +54,12 @@ public class GrpcClientAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean(ChannelCredentialsProvider.class)
-	public NamedChannelCredentialsProvider channelCredentialsProvider(GrpcClientProperties channels,
-			SslBundles bundles) {
+	NamedChannelCredentialsProvider channelCredentialsProvider(GrpcClientProperties channels, SslBundles bundles) {
 		return new NamedChannelCredentialsProvider(bundles, channels);
 	}
 
 	@Bean
-	public GrpcChannelBuilderCustomizer clientPropertiesChannelCustomizer(GrpcClientProperties properties) {
+	GrpcChannelBuilderCustomizer clientPropertiesChannelCustomizer(GrpcClientProperties properties) {
 		return new ClientPropertiesChannelBuilderCustomizer(properties);
 	}
 

--- a/spring-grpc-test/src/main/java/org/springframework/grpc/test/InProcessGrpcServerFactoryAutoConfiguration.java
+++ b/spring-grpc-test/src/main/java/org/springframework/grpc/test/InProcessGrpcServerFactoryAutoConfiguration.java
@@ -20,11 +20,11 @@ import java.util.List;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnNotWebApplication;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.grpc.autoconfigure.client.ClientInterceptorsConfiguration;
 import org.springframework.grpc.autoconfigure.client.GrpcClientAutoConfiguration;
 import org.springframework.grpc.autoconfigure.server.GrpcServerFactoryAutoConfiguration;
 import org.springframework.grpc.client.ClientInterceptorsConfigurer;
@@ -38,6 +38,7 @@ import io.grpc.inprocess.InProcessServerBuilder;
 @ConditionalOnProperty(prefix = "spring.grpc.inprocess", name = "enabled", havingValue = "true", matchIfMissing = true)
 @ConditionalOnClass(BindableService.class)
 @ConditionalOnNotWebApplication
+@Import(ClientInterceptorsConfiguration.class)
 public class InProcessGrpcServerFactoryAutoConfiguration {
 
 	private final String address = InProcessServerBuilder.generateName();
@@ -49,12 +50,6 @@ public class InProcessGrpcServerFactoryAutoConfiguration {
 		InProcessGrpcServerFactory factory = new InProcessGrpcServerFactory(address, customizers);
 		grpcServicesDiscoverer.findServices().forEach(factory::addService);
 		return factory;
-	}
-
-	@Bean
-	@ConditionalOnMissingBean
-	ClientInterceptorsConfigurer inProcessClientInterceptorsConfigurer(ApplicationContext applicationContext) {
-		return new ClientInterceptorsConfigurer(applicationContext);
 	}
 
 	@Bean


### PR DESCRIPTION
This commit extracts the client interceptors configuration portion out of the client autoconfiguration so that the testing module autoconfiguration can also import the client interceptors configuration directly.

Resolves #73