### PR TITLE
Fix config props defaults and descriptions

### DIFF
--- a/spring-grpc-docs/src/main/antora/modules/ROOT/partials/_configprops.adoc
+++ b/spring-grpc-docs/src/main/antora/modules/ROOT/partials/_configprops.adoc
@@ -2,14 +2,47 @@
 |Name | Default | Description
 
 |spring.grpc.client.channels |  | 
+|spring.grpc.client.default-channel.address | `+++static://localhost:9090+++` | The target address uri to connect to.
+|spring.grpc.client.default-channel.default-load-balancing-policy | `+++round_robin+++` | The default load balancing policy the channel should use.
+|spring.grpc.client.default-channel.enable-keep-alive | `+++false+++` | Whether keep alive is enabled on the channel.
+|spring.grpc.client.default-channel.health.enabled | `+++false+++` | Whether to enable client-side health check for the channel.
+|spring.grpc.client.default-channel.health.service-name |  | Name of the service to check health on.
+|spring.grpc.client.default-channel.idle-timeout | `+++20s+++` | The duration without ongoing RPCs before going to idle mode.
+|spring.grpc.client.default-channel.keep-alive-time | `+++5m+++` | The delay before sending a keepAlive. Note that shorter intervals increase the network burden for the server and this value can not be lower than 'permitKeepAliveTime' on the server.
+|spring.grpc.client.default-channel.keep-alive-timeout | `+++20s+++` | The default timeout for a keepAlives ping request.
+|spring.grpc.client.default-channel.keep-alive-without-calls | `+++false+++` | Whether a keepAlive will be performed when there are no outstanding RPC on a connection.
+|spring.grpc.client.default-channel.max-inbound-message-size | `+++4194304B+++` | Maximum message size allowed to be received by the channel (default 4MiB). Set to '-1' to use the highest possible limit (not recommended).
+|spring.grpc.client.default-channel.max-inbound-metadata-size | `+++8192B+++` | Maximum metadata size allowed to be received by the channel (default 8KiB). Set to '-1' to use the highest possible limit (not recommended).
+|spring.grpc.client.default-channel.negotiation-type |  | The negotiation type for the channel.
+|spring.grpc.client.default-channel.secure | `+++true+++` | Flag to say that strict SSL checks are not enabled (so the remote certificate could be anonymous).
+|spring.grpc.client.default-channel.ssl.bundle |  | SSL bundle name.
+|spring.grpc.client.default-channel.ssl.enabled |  | Whether to enable SSL support. Enabled automatically if "bundle" is provided unless specified otherwise.
+|spring.grpc.client.default-channel.user-agent |  | The custom User-Agent for the channel.
 |spring.grpc.server.address |  | The address to bind to. could be a host:port combination or a pseudo URL like static://host:port. Can not be set if host or port are set independently.
 |spring.grpc.server.exception-handling.enabled | `+++true+++` | Whether to enable user-defined global exception handling on the gRPC server.
-|spring.grpc.server.host |  | Server address to bind to. The default is any IP address ('*').
-|spring.grpc.server.max-inbound-message-size |  | Maximum message size allowed to be received by the server (default 4MiB).
-|spring.grpc.server.max-inbound-metadata-size |  | Maximum metadata size allowed to be received by the server (default 8KiB).
+|spring.grpc.server.health.actuator.enabled | `+++true+++` | Whether to adapt Actuator health indicators into gRPC health checks.
+|spring.grpc.server.health.actuator.health-indicator-paths |  | List of Actuator health indicator paths to adapt into gRPC health checks.
+|spring.grpc.server.health.actuator.update-initial-delay | `+++5s+++` | The initial delay before updating the health status the very first time.
+|spring.grpc.server.health.actuator.update-overall-health | `+++true+++` | Whether to update the overall gRPC server health (the '' service) with the aggregate status of the configured health indicators.
+|spring.grpc.server.health.actuator.update-rate | `+++5s+++` | How often to update the health status.
+|spring.grpc.server.health.enabled | `+++true+++` | Whether to auto-configure Health feature on the gRPC server.
+|spring.grpc.server.host | `+++*+++` | Server address to bind to. The default is any IP address ('*').
+|spring.grpc.server.keep-alive.max-age |  | Maximum time a connection may exist before being gracefully terminated (default infinite).
+|spring.grpc.server.keep-alive.max-age-grace |  | Maximum time for graceful connection termination (default infinite).
+|spring.grpc.server.keep-alive.max-idle |  | Maximum time a connection can remain idle before being gracefully terminated (default infinite).
+|spring.grpc.server.keep-alive.permit-time | `+++5m+++` | Maximum keep-alive time clients are permitted to configure (default 5m).
+|spring.grpc.server.keep-alive.permit-without-calls | `+++false+++` | Whether clients are permitted to send keep alive pings when there are no outstanding RPCs on the connection (default false).
+|spring.grpc.server.keep-alive.time | `+++2h+++` | Duration without read activity before sending a keep alive ping (default 2h).
+|spring.grpc.server.keep-alive.timeout | `+++20s+++` | Maximum time to wait for read activity after sending a keep alive ping. If sender does not receive an acknowledgment within this time, it will close the connection (default 20s).
+|spring.grpc.server.max-inbound-message-size | `+++4194304B+++` | Maximum message size allowed to be received by the server (default 4MiB).
+|spring.grpc.server.max-inbound-metadata-size | `+++8192B+++` | Maximum metadata size allowed to be received by the server (default 8KiB).
 |spring.grpc.server.observations.enabled | `+++true+++` | Whether to enable Observations on the server.
 |spring.grpc.server.port | `+++9090+++` | Server port to listen on. When the value is 0, a random available port is selected. The default is 9090.
 |spring.grpc.server.reflection.enabled | `+++true+++` | Whether to enable Reflection on the gRPC server.
-|spring.grpc.server.shutdown-grace-period |  | Maximum time to wait for the server to gracefully shutdown. When the value is negative, the server waits forever. When the value is 0, the server will force shutdown immediately. The default is 30 seconds.
+|spring.grpc.server.shutdown-grace-period | `+++30s+++` | Maximum time to wait for the server to gracefully shutdown. When the value is negative, the server waits forever. When the value is 0, the server will force shutdown immediately. The default is 30 seconds.
+|spring.grpc.server.ssl.bundle |  | SSL bundle name.
+|spring.grpc.server.ssl.client-auth |  | Client authentication mode.
+|spring.grpc.server.ssl.enabled |  | Whether to enable SSL support. Enabled automatically if "bundle" is provided unless specified otherwise.
+|spring.grpc.server.ssl.secure | `+++true+++` | Flag to indicate that client authentication is secure (i.e. certificates are checked). Do not set this to false in production.
 
 |===

--- a/spring-grpc-spring-boot-autoconfigure/src/test/java/org/springframework/grpc/autoconfigure/client/GrpcClientPropertiesTests.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/test/java/org/springframework/grpc/autoconfigure/client/GrpcClientPropertiesTests.java
@@ -51,7 +51,7 @@ class GrpcClientPropertiesTests {
 		void withDefaultValues() {
 			Map<String, String> map = new HashMap<>();
 			// we have to at least bind one property or bind() fails
-			map.put("spring.grpc.client.default-channel.max-inbound-message-size", "200");
+			map.put("spring.grpc.client.default-channel.enable-keep-alive", "false");
 			GrpcClientProperties properties = bindProperties(map);
 			var defaultChannel = properties.getDefaultChannel();
 			assertThat(defaultChannel.getAddress()).isEqualTo("static://localhost:9090");
@@ -65,8 +65,8 @@ class GrpcClientPropertiesTests {
 			assertThat(defaultChannel.getKeepAliveTimeout()).isEqualTo(Duration.ofSeconds(20));
 			assertThat(defaultChannel.isEnableKeepAlive()).isFalse();
 			assertThat(defaultChannel.isKeepAliveWithoutCalls()).isFalse();
-			assertThat(defaultChannel.getMaxInboundMessageSize()).isEqualTo(DataSize.ofBytes(200));
-			assertThat(defaultChannel.getMaxInboundMetadataSize()).isNull();
+			assertThat(defaultChannel.getMaxInboundMessageSize()).isEqualTo(DataSize.ofBytes(4194304));
+			assertThat(defaultChannel.getMaxInboundMetadataSize()).isEqualTo(DataSize.ofBytes(8192));
 			assertThat(defaultChannel.getUserAgent()).isNull();
 			assertThat(defaultChannel.isSecure()).isTrue();
 			assertThat(defaultChannel.getSsl().isEnabled()).isFalse();
@@ -146,35 +146,8 @@ class GrpcClientPropertiesTests {
 		void withNoUserSpecifiedValues() {
 			GrpcClientProperties properties = new GrpcClientProperties();
 			var defaultChannel = properties.getDefaultChannel();
-			var newChannel = new GrpcClientProperties.NamedChannel();
-			newChannel.copyDefaultsFrom(defaultChannel);
+			var newChannel = defaultChannel.copy();
 			assertThat(newChannel).usingRecursiveComparison().isEqualTo(defaultChannel);
-		}
-
-		@Test
-		void withUserSpecifiedValuesAreRetained() {
-			GrpcClientProperties properties = new GrpcClientProperties();
-			var defaultChannel = properties.getDefaultChannel();
-			var newChannel = new GrpcClientProperties.NamedChannel();
-			newChannel.setAddress("static://my-server:9999");
-			newChannel.setDefaultLoadBalancingPolicy("custom");
-			newChannel.getHealth().setEnabled(true);
-			newChannel.getHealth().setServiceName("custom-service");
-			newChannel.setNegotiationType(NegotiationType.TLS);
-			newChannel.setEnableKeepAlive(true);
-			newChannel.setIdleTimeout(Duration.ofMinutes(1));
-			newChannel.setKeepAliveTime(Duration.ofMinutes(4));
-			newChannel.setKeepAliveTimeout(Duration.ofMinutes(6));
-			newChannel.setKeepAliveWithoutCalls(true);
-			newChannel.setMaxInboundMessageSize(DataSize.ofMegabytes(100));
-			newChannel.setMaxInboundMetadataSize(DataSize.ofMegabytes(200));
-			newChannel.setUserAgent("me");
-			newChannel.setSecure(false);
-			newChannel.getSsl().setEnabled(true);
-			newChannel.getSsl().setBundle("custom-bundle");
-			newChannel.copyDefaultsFrom(defaultChannel);
-			assertThat(newChannel).usingRecursiveComparison().isNotEqualTo(defaultChannel);
-			assertThat(newChannel).usingRecursiveComparison().isEqualTo(newChannel);
 		}
 
 	}


### PR DESCRIPTION
This commit simplifies the client properties by setting the default values directly on the properties and removes markdown from the property javadocs. 
This improves end user experience by adding default values and descriptions to the generated config props docs.