### PR TITLE
Disable in-process transport by default and add @AutoConfigureInProcessTransport annotation

### DIFF
--- a/samples/grpc-server-netty-shaded/src/test/java/com/example/demo/DemoApplicationTests.java
+++ b/samples/grpc-server-netty-shaded/src/test/java/com/example/demo/DemoApplicationTests.java
@@ -19,8 +19,7 @@ import com.example.demo.proto.HelloReply;
 import com.example.demo.proto.HelloRequest;
 import com.example.demo.proto.SimpleGrpc;
 
-@SpringBootTest(properties = { "spring.grpc.client.channels.test.address=static://localhost:0",
-		"spring.grpc.inprocess.enabled=false" })
+@SpringBootTest(properties = { "spring.grpc.client.channels.test.address=static://localhost:0" })
 public class DemoApplicationTests {
 
 	private static Log log = LogFactory.getLog(DemoApplicationTests.class);

--- a/samples/grpc-server/src/test/java/org/springframework/grpc/sample/GrpcServerApplicationTests.java
+++ b/samples/grpc-server/src/test/java/org/springframework/grpc/sample/GrpcServerApplicationTests.java
@@ -18,14 +18,13 @@ import org.springframework.grpc.sample.proto.SimpleGrpc;
 import org.springframework.grpc.test.LocalGrpcPort;
 import org.springframework.test.annotation.DirtiesContext;
 
-@SpringBootTest(properties = { "spring.grpc.server.port=0", "spring.grpc.inprocess.enabled=false" })
+@SpringBootTest(properties = { "spring.grpc.server.port=0" })
 public class GrpcServerApplicationTests {
 
 	private static Log log = LogFactory.getLog(GrpcServerApplicationTests.class);
 
 	public static void main(String[] args) {
-		new SpringApplicationBuilder(GrpcServerApplication.class, ExtraConfiguration.class)
-			.run("--spring.grpc.inprocess.enabled=false");
+		new SpringApplicationBuilder(GrpcServerApplication.class, ExtraConfiguration.class).run();
 	}
 
 	@Autowired

--- a/samples/grpc-server/src/test/java/org/springframework/grpc/sample/GrpcServerHealthIntegrationTests.java
+++ b/samples/grpc-server/src/test/java/org/springframework/grpc/sample/GrpcServerHealthIntegrationTests.java
@@ -36,6 +36,7 @@ import org.springframework.grpc.client.GrpcChannelFactory;
 import org.springframework.grpc.sample.proto.HelloReply;
 import org.springframework.grpc.sample.proto.HelloRequest;
 import org.springframework.grpc.sample.proto.SimpleGrpc;
+import org.springframework.grpc.test.AutoConfigureInProcessTransport;
 import org.springframework.test.annotation.DirtiesContext;
 
 import io.grpc.ManagedChannel;
@@ -52,7 +53,7 @@ import io.grpc.protobuf.services.HealthStatusManager;
 class GrpcServerHealthIntegrationTests {
 
 	@Nested
-	@SpringBootTest(properties = { "spring.grpc.inprocess.enabled=false", "spring.grpc.server.port=0",
+	@SpringBootTest(properties = { "spring.grpc.server.port=0",
 			"spring.grpc.client.channels.health-test.address=static://0.0.0.0:${local.grpc.port}",
 			"spring.grpc.client.channels.health-test.health.enabled=true",
 			"spring.grpc.client.channels.health-test.health.service-name=my-service" })
@@ -112,6 +113,7 @@ class GrpcServerHealthIntegrationTests {
 	@SpringBootTest(properties = { "spring.grpc.server.health.actuator.health-indicator-paths=custom",
 			"spring.grpc.server.health.actuator.update-initial-delay=3s",
 			"spring.grpc.server.health.actuator.update-rate=3s", "management.health.defaults.enabled=true" })
+	@AutoConfigureInProcessTransport
 	@DirtiesContext
 	class WithActuatorHealthAdapter {
 

--- a/samples/grpc-server/src/test/java/org/springframework/grpc/sample/GrpcServerIntegrationTests.java
+++ b/samples/grpc-server/src/test/java/org/springframework/grpc/sample/GrpcServerIntegrationTests.java
@@ -31,6 +31,7 @@ import org.springframework.grpc.sample.proto.HelloReply;
 import org.springframework.grpc.sample.proto.HelloRequest;
 import org.springframework.grpc.sample.proto.SimpleGrpc;
 import org.springframework.grpc.server.GrpcServerFactory;
+import org.springframework.grpc.test.AutoConfigureInProcessTransport;
 import org.springframework.grpc.test.LocalGrpcPort;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
@@ -47,6 +48,7 @@ class GrpcServerIntegrationTests {
 
 	@Nested
 	@SpringBootTest
+	@AutoConfigureInProcessTransport
 	class ServerWithInProcessChannel {
 
 		@Test
@@ -58,6 +60,7 @@ class GrpcServerIntegrationTests {
 
 	@Nested
 	@SpringBootTest
+	@AutoConfigureInProcessTransport
 	class ServerWithException {
 
 		@Test
@@ -84,6 +87,7 @@ class GrpcServerIntegrationTests {
 
 	@Nested
 	@SpringBootTest("spring.grpc.server.exception-handler.enabled=false")
+	@AutoConfigureInProcessTransport
 	class ServerWithUnhandledException {
 
 		@Test
@@ -109,8 +113,7 @@ class GrpcServerIntegrationTests {
 	}
 
 	@Nested
-	@SpringBootTest(properties = { "spring.grpc.server.host=0.0.0.0", "spring.grpc.server.port=0",
-			"spring.grpc.inprocess.enabled=false" })
+	@SpringBootTest(properties = { "spring.grpc.server.host=0.0.0.0", "spring.grpc.server.port=0" })
 	class ServerWithAnyIPv4AddressAndRandomPort {
 
 		@Test
@@ -122,8 +125,7 @@ class GrpcServerIntegrationTests {
 	}
 
 	@Nested
-	@SpringBootTest(properties = { "spring.grpc.server.host=::", "spring.grpc.server.port=0",
-			"spring.grpc.inprocess.enabled=false" })
+	@SpringBootTest(properties = { "spring.grpc.server.host=::", "spring.grpc.server.port=0" })
 	class ServerWithAnyIPv6AddressAndRandomPort {
 
 		@Test
@@ -135,8 +137,7 @@ class GrpcServerIntegrationTests {
 	}
 
 	@Nested
-	@SpringBootTest(properties = { "spring.grpc.server.host=127.0.0.1", "spring.grpc.server.port=0",
-			"spring.grpc.inprocess.enabled=false" })
+	@SpringBootTest(properties = { "spring.grpc.server.host=127.0.0.1", "spring.grpc.server.port=0" })
 	class ServerWithLocalhostAndRandomPort {
 
 		@Test
@@ -149,8 +150,7 @@ class GrpcServerIntegrationTests {
 
 	@Nested
 	@SpringBootTest(properties = { "spring.grpc.server.port=0",
-			"spring.grpc.client.channels.test-channel.address=static://0.0.0.0:${local.grpc.port}",
-			"spring.grpc.inprocess.enabled=false" })
+			"spring.grpc.client.channels.test-channel.address=static://0.0.0.0:${local.grpc.port}" })
 	@DirtiesContext
 	class ServerConfiguredWithStaticClientChannel {
 
@@ -162,8 +162,7 @@ class GrpcServerIntegrationTests {
 	}
 
 	@Nested
-	@SpringBootTest(
-			properties = { "spring.grpc.server.address=unix:unix-test-channel", "spring.grpc.inprocess.enabled=false" })
+	@SpringBootTest(properties = { "spring.grpc.server.address=unix:unix-test-channel" })
 	@EnabledOnOs(OS.LINUX)
 	class ServerWithUnixDomain {
 
@@ -178,7 +177,7 @@ class GrpcServerIntegrationTests {
 	@SpringBootTest(properties = { "spring.grpc.server.port=0",
 			"spring.grpc.client.channels.test-channel.address=static://0.0.0.0:${local.grpc.port}",
 			"spring.grpc.client.channels.test-channel.negotiation-type=TLS",
-			"spring.grpc.client.channels.test-channel.secure=false", "spring.grpc.inprocess.enabled=false" })
+			"spring.grpc.client.channels.test-channel.secure=false" })
 	@ActiveProfiles("ssl")
 	@DirtiesContext
 	class ServerWithSsl {
@@ -196,7 +195,7 @@ class GrpcServerIntegrationTests {
 			"spring.grpc.client.channels.test-channel.address=static://0.0.0.0:${local.grpc.port}",
 			"spring.grpc.client.channels.test-channel.ssl.bundle=ssltest",
 			"spring.grpc.client.channels.test-channel.negotiation-type=TLS",
-			"spring.grpc.client.channels.test-channel.secure=false", "spring.grpc.inprocess.enabled=false" })
+			"spring.grpc.client.channels.test-channel.secure=false" })
 	@ActiveProfiles("ssl")
 	@DirtiesContext
 	class ServerWithClientAuth {

--- a/samples/grpc-tomcat/src/test/java/org/springframework/grpc/sample/GrpcServerApplicationTests.java
+++ b/samples/grpc-tomcat/src/test/java/org/springframework/grpc/sample/GrpcServerApplicationTests.java
@@ -16,9 +16,11 @@ import org.springframework.grpc.client.GrpcChannelFactory;
 import org.springframework.grpc.sample.proto.HelloReply;
 import org.springframework.grpc.sample.proto.HelloRequest;
 import org.springframework.grpc.sample.proto.SimpleGrpc;
+import org.springframework.grpc.test.AutoConfigureInProcessTransport;
 import org.springframework.test.annotation.DirtiesContext;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureInProcessTransport
 public class GrpcServerApplicationTests {
 
 	private static Log log = LogFactory.getLog(GrpcServerApplicationTests.class);

--- a/spring-grpc-test/src/main/java/org/springframework/grpc/test/AutoConfigureInProcessTransport.java
+++ b/spring-grpc-test/src/main/java/org/springframework/grpc/test/AutoConfigureInProcessTransport.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.grpc.test;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+
+/**
+ * Annotation that can be applied to a test class to enable auto-configuration for
+ * in-process transport.
+ *
+ * @author Andrey Litvitski
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@ImportAutoConfiguration
+public @interface AutoConfigureInProcessTransport {
+
+	boolean enabled() default true;
+
+}

--- a/spring-grpc-test/src/main/java/org/springframework/grpc/test/InProcessGrpcServerFactoryAutoConfiguration.java
+++ b/spring-grpc-test/src/main/java/org/springframework/grpc/test/InProcessGrpcServerFactoryAutoConfiguration.java
@@ -35,7 +35,7 @@ import io.grpc.BindableService;
 import io.grpc.inprocess.InProcessServerBuilder;
 
 @AutoConfiguration(before = { GrpcServerFactoryAutoConfiguration.class, GrpcClientAutoConfiguration.class })
-@ConditionalOnProperty(prefix = "spring.grpc.inprocess", name = "enabled", havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(prefix = "spring.grpc.inprocess", name = "enabled", havingValue = "true")
 @ConditionalOnClass(BindableService.class)
 @ConditionalOnNotWebApplication
 @Import(ClientInterceptorsConfiguration.class)

--- a/spring-grpc-test/src/main/java/org/springframework/grpc/test/InProcessTransportContextCustomizerFactory.java
+++ b/spring-grpc-test/src/main/java/org/springframework/grpc/test/InProcessTransportContextCustomizerFactory.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.grpc.test;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.Environment;
+import org.springframework.test.context.ContextConfigurationAttributes;
+import org.springframework.test.context.ContextCustomizer;
+import org.springframework.test.context.ContextCustomizerFactory;
+import org.springframework.test.context.MergedContextConfiguration;
+import org.springframework.test.context.TestContextAnnotationUtils;
+
+class InProcessTransportContextCustomizerFactory implements ContextCustomizerFactory {
+
+	static final String AUTO_CONFIGURE_PROPERTY = "spring.grpc.inprocess.auto-configure";
+
+	@Override
+	public ContextCustomizer createContextCustomizer(Class<?> testClass,
+			List<ContextConfigurationAttributes> configAttributes) {
+		AutoConfigureInProcessTransport annotation = TestContextAnnotationUtils.findMergedAnnotation(testClass,
+				AutoConfigureInProcessTransport.class);
+		return new InProcessTransportContextCustomizer(annotation);
+	}
+
+	private static class InProcessTransportContextCustomizer implements ContextCustomizer {
+
+		private final AutoConfigureInProcessTransport annotation;
+
+		InProcessTransportContextCustomizer(AutoConfigureInProcessTransport annotation) {
+			this.annotation = annotation;
+		}
+
+		@Override
+		public void customizeContext(ConfigurableApplicationContext context, MergedContextConfiguration mergedConfig) {
+			if (isEnabled(context.getEnvironment())) {
+				TestPropertyValues.of("spring.grpc.inprocess.enabled=true").applyTo(context);
+			}
+		}
+
+		private boolean isEnabled(Environment environment) {
+			if (this.annotation != null) {
+				return this.annotation.enabled();
+			}
+
+			return environment.getProperty(AUTO_CONFIGURE_PROPERTY, Boolean.class, false);
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+
+			InProcessTransportContextCustomizer that = (InProcessTransportContextCustomizer) o;
+
+			return Objects.equals(this.annotation, that.annotation);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(annotation);
+		}
+
+	}
+
+}

--- a/spring-grpc-test/src/main/resources/META-INF/spring.factories
+++ b/spring-grpc-test/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,7 @@
 # Application Context Initializers
 org.springframework.context.ApplicationContextInitializer=\
 org.springframework.grpc.test.ServerPortInfoApplicationContextInitializer
+
+# Environment Customizer Factories
+org.springframework.test.context.ContextCustomizerFactory=\
+org.springframework.grpc.test.InProcessTransportContextCustomizerFactory


### PR DESCRIPTION
Here I have added the `AutoConfigureInProcessTransport` annotation which should be set over the test where we want in-process transport to be enabled. I also added the class `InProcessTransportEnvironmentPostProcessor` which implements `EnvironmentPostProcessor` and where I use `AnnotationUtils.findAnnotation` to check if the startup class is marked with an annotation or not. If yes, then we need to enable in-process transport and we set `spring.grpc.inprocess.enabled=true`. I also set `matchIfMissing` to false in `InProcessGrpcServerFactoryAutoConfiguration` (ignored as it is by default) so that in-process will default to false.

Closes #77 