### PR TITLE
Remove wrong example in documentation

### DIFF
--- a/spring-grpc-docs/src/main/antora/modules/ROOT/pages/client.adoc
+++ b/spring-grpc-docs/src/main/antora/modules/ROOT/pages/client.adoc
@@ -138,7 +138,7 @@ The `@Bean` has to be marked as `@Lazy` to ensure that the port is available whe
 @Bean
 @Lazy
 SimpleGrpc.SimpleBlockingStub stub(GrpcChannelFactory channels, @LocalGrpcPort int port) {
-	return SimpleGrpc.newBlockingStub(channels.createChannel("0.0.0.0:" + port).build());
+	return SimpleGrpc.newBlockingStub(channels.createChannel("0.0.0.0:" + port));
 }
 ----
 


### PR DESCRIPTION
Hi, I found a wrong example in documentation:

```java
@Bean
SimpleGrpc.SimpleBlockingStub stub(GrpcChannelFactory channels) {
	return SimpleGrpc.newBlockingStub(channels.createChannel("local").build());
}
```

Method build doesn't exist in createChannel, and is unnecessary.