### PR TITLE
Fix documentation on testing server application

### DIFF
--- a/spring-grpc-docs/src/main/antora/modules/ROOT/pages/server.adoc
+++ b/spring-grpc-docs/src/main/antora/modules/ROOT/pages/server.adoc
@@ -160,9 +160,9 @@ A `GrpcExceptionHandler` can be used to handle exceptions of a specific type, re
 
 == Testing
 
-If you include `spring-grpc-test` in your project, your gRPC server in a `@SpringBootTest` will be started in-process (i.e. not listening on a network port).
+If you include `spring-grpc-test` in your project, your gRPC server in a `@SpringBootTest` can be started in-process (i.e. not listening on a network port) by enabling the in-process server
 All clients that connect to any server via the autoconfigured `GrpcChannelFactory` will be able to connect to it.
-You can switch the in-process server off by setting `spring.grpc.in-process.enabled` to `false`.
+You can switch the in-process server on by setting `spring.grpc.inprocess.enabled` to `true`.
 
 == Security
 


### PR DESCRIPTION
Fixes #101

The main problem is that inprocess has recently had to be specified manually (we've been working on this here #88).