### PR TITLE
Add fine-grained starter modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
 		<module>spring-grpc-spring-boot-autoconfigure</module>
 		<module>spring-grpc-spring-boot-starter</module>
 		<module>spring-grpc-client-spring-boot-starter</module>
+		<module>spring-grpc-server-spring-boot-starter</module>
 		<module>spring-grpc-server-web-spring-boot-starter</module>
 		<module>samples</module>
 	</modules>

--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,8 @@
 		<module>spring-grpc-test</module>
 		<module>spring-grpc-spring-boot-autoconfigure</module>
 		<module>spring-grpc-spring-boot-starter</module>
-        <module>spring-grpc-client-spring-boot-starter</module>
-        <module>spring-grpc-server-web-spring-boot-starter</module>
+		<module>spring-grpc-client-spring-boot-starter</module>
+		<module>spring-grpc-server-web-spring-boot-starter</module>
 		<module>samples</module>
 	</modules>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
 		<module>spring-grpc-spring-boot-autoconfigure</module>
 		<module>spring-grpc-spring-boot-starter</module>
         <module>spring-grpc-client-spring-boot-starter</module>
+        <module>spring-grpc-server-web-spring-boot-starter</module>
 		<module>samples</module>
 	</modules>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
 		<module>spring-grpc-test</module>
 		<module>spring-grpc-spring-boot-autoconfigure</module>
 		<module>spring-grpc-spring-boot-starter</module>
+        <module>spring-grpc-client-spring-boot-starter</module>
 		<module>samples</module>
 	</modules>
 

--- a/samples/grpc-server-netty-shaded/build.gradle
+++ b/samples/grpc-server-netty-shaded/build.gradle
@@ -29,14 +29,11 @@ dependencyManagement {
 }
 
 dependencies {
-    implementation 'org.springframework.grpc:spring-grpc-spring-boot-starter'
+    implementation ('org.springframework.grpc:spring-grpc-spring-boot-starter') {
+		exclude group: "io.grpc", module: "grpc-netty"
+	}
     implementation 'io.grpc:grpc-netty-shaded'
     implementation 'io.grpc:grpc-services'
-    modules {
-        module("io.grpc:grpc-netty") {
-            replacedBy("io.grpc:grpc-netty-shaded", "Use Netty shaded instead of regular Netty")
-        }
-    }
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.grpc:spring-grpc-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/samples/grpc-server-netty-shaded/build.gradle
+++ b/samples/grpc-server-netty-shaded/build.gradle
@@ -29,11 +29,14 @@ dependencyManagement {
 }
 
 dependencies {
-    implementation ('org.springframework.grpc:spring-grpc-spring-boot-starter') {
-        exclude group: "io.grpc", module: "grpc-netty"
-    }
+    implementation 'org.springframework.grpc:spring-grpc-spring-boot-starter'
     implementation 'io.grpc:grpc-netty-shaded'
     implementation 'io.grpc:grpc-services'
+    modules {
+        module("io.grpc:grpc-netty") {
+            replacedBy("io.grpc:grpc-netty-shaded", "Use Netty shaded instead of regular Netty")
+        }
+    }
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.grpc:spring-grpc-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/samples/grpc-server-netty-shaded/build.gradle
+++ b/samples/grpc-server-netty-shaded/build.gradle
@@ -30,8 +30,8 @@ dependencyManagement {
 
 dependencies {
     implementation ('org.springframework.grpc:spring-grpc-spring-boot-starter') {
-		exclude group: "io.grpc", module: "grpc-netty"
-	}
+        exclude group: "io.grpc", module: "grpc-netty"
+    }
     implementation 'io.grpc:grpc-netty-shaded'
     implementation 'io.grpc:grpc-services'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/samples/grpc-tomcat-secure/pom.xml
+++ b/samples/grpc-tomcat-secure/pom.xml
@@ -47,11 +47,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.grpc</groupId>
-			<artifactId>spring-grpc-spring-boot-starter</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-grpc-server-web-spring-boot-starter</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -60,10 +56,6 @@
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-services</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>io.grpc</groupId>
-			<artifactId>grpc-servlet-jakarta</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.grpc</groupId>

--- a/samples/grpc-tomcat/pom.xml
+++ b/samples/grpc-tomcat/pom.xml
@@ -47,19 +47,11 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.grpc</groupId>
-			<artifactId>spring-grpc-spring-boot-starter</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-grpc-server-web-spring-boot-starter</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-services</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>io.grpc</groupId>
-			<artifactId>grpc-servlet-jakarta</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-grpc-client-spring-boot-starter/pom.xml
+++ b/spring-grpc-client-spring-boot-starter/pom.xml
@@ -8,10 +8,10 @@
 		<artifactId>spring-grpc</artifactId>
 		<version>0.4.0-SNAPSHOT</version>
 	</parent>
-	<artifactId>spring-grpc-spring-boot-starter</artifactId>
+	<artifactId>spring-grpc-client-spring-boot-starter</artifactId>
 	<packaging>jar</packaging>
-	<name>Spring gRPC Server Spring Boot Starter</name>
-	<description>Spring gRPC Server Spring Boot Starter</description>
+	<name>Spring gRPC Client Spring Boot Starter</name>
+	<description>Spring gRPC Client Spring Boot Starter</description>
 
 	<dependencies>
 		<dependency>
@@ -30,8 +30,7 @@
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
-            <artifactId>grpc-services</artifactId>
-            <optional>true</optional>
+            <artifactId>grpc-stub</artifactId>
         </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-grpc-client-spring-boot-starter/pom.xml
+++ b/spring-grpc-client-spring-boot-starter/pom.xml
@@ -24,14 +24,14 @@
 			<artifactId>spring-grpc-spring-boot-autoconfigure</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-netty</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-stub</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-netty</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-stub</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter</artifactId>

--- a/spring-grpc-core/pom.xml
+++ b/spring-grpc-core/pom.xml
@@ -54,6 +54,7 @@
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-netty</artifactId>
+            <optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>io.grpc</groupId>

--- a/spring-grpc-core/pom.xml
+++ b/spring-grpc-core/pom.xml
@@ -32,6 +32,10 @@
 			<artifactId>spring-security-web</artifactId>
 			<optional>true</optional>
 		</dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-core</artifactId>
+        </dependency>
 		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-oauth2-resource-server</artifactId>

--- a/spring-grpc-core/pom.xml
+++ b/spring-grpc-core/pom.xml
@@ -36,6 +36,11 @@
             <groupId>io.grpc</groupId>
             <artifactId>grpc-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-stub</artifactId>
+            <optional>true</optional>
+        </dependency>
 		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-oauth2-resource-server</artifactId>
@@ -88,12 +93,6 @@
 			<groupId>com.google.api.grpc</groupId>
 			<artifactId>proto-google-common-protos</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>io.grpc</groupId>
-			<artifactId>grpc-stub</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/spring-grpc-core/pom.xml
+++ b/spring-grpc-core/pom.xml
@@ -32,15 +32,15 @@
 			<artifactId>spring-security-web</artifactId>
 			<optional>true</optional>
 		</dependency>
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-stub</artifactId>
-            <optional>true</optional>
-        </dependency>
+		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-stub</artifactId>
+			<optional>true</optional>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-oauth2-resource-server</artifactId>
@@ -59,7 +59,7 @@
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-netty</artifactId>
-            <optional>true</optional>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>io.grpc</groupId>

--- a/spring-grpc-dependencies/pom.xml
+++ b/spring-grpc-dependencies/pom.xml
@@ -82,6 +82,11 @@
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.grpc</groupId>
+				<artifactId>spring-grpc-server-spring-boot-starter</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.grpc</groupId>
 				<artifactId>spring-grpc-server-web-spring-boot-starter</artifactId>
 				<version>${project.version}</version>
 			</dependency>

--- a/spring-grpc-dependencies/pom.xml
+++ b/spring-grpc-dependencies/pom.xml
@@ -75,16 +75,16 @@
 				<artifactId>spring-grpc-spring-boot-starter</artifactId>
 				<version>${project.version}</version>
 			</dependency>
-            <dependency>
-                <groupId>org.springframework.grpc</groupId>
-                <artifactId>spring-grpc-client-spring-boot-starter</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.grpc</groupId>
-                <artifactId>spring-grpc-server-web-spring-boot-starter</artifactId>
-                <version>${project.version}</version>
-            </dependency>
+			<dependency>
+				<groupId>org.springframework.grpc</groupId>
+				<artifactId>spring-grpc-client-spring-boot-starter</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.grpc</groupId>
+				<artifactId>spring-grpc-server-web-spring-boot-starter</artifactId>
+				<version>${project.version}</version>
+			</dependency>
 			<!-- Utilities -->
 			<dependency>
 				<groupId>org.springframework.grpc</groupId>

--- a/spring-grpc-dependencies/pom.xml
+++ b/spring-grpc-dependencies/pom.xml
@@ -75,6 +75,16 @@
 				<artifactId>spring-grpc-spring-boot-starter</artifactId>
 				<version>${project.version}</version>
 			</dependency>
+            <dependency>
+                <groupId>org.springframework.grpc</groupId>
+                <artifactId>spring-grpc-client-spring-boot-starter</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.grpc</groupId>
+                <artifactId>spring-grpc-server-web-spring-boot-starter</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 			<!-- Utilities -->
 			<dependency>
 				<groupId>org.springframework.grpc</groupId>

--- a/spring-grpc-docs/src/main/antora/modules/ROOT/pages/server.adoc
+++ b/spring-grpc-docs/src/main/antora/modules/ROOT/pages/server.adoc
@@ -59,21 +59,15 @@ dependencies {
 == Servlet Server
 
 Any servlet container can be used to run a gRPC server.
-Spring gRPC includes autoconfiguration that configures the server to use the servlet container if it detects that it is in a web application, so all you have to do is include `spring-boot-starter-web` and the `grpc-servlet` dependnecy in your application.
+Spring gRPC includes autoconfiguration that configures the server to use the servlet container if it detects that it is in a web application.
+Spring gRPC also provides a convenience starter that includes the required dependencies (`spring-boot-starter-web` and the `grpc-servlet-jakarta`) for this scenario.
+So all you have to do is include the `spring-boot-starter-web` dependency as follows:
 
 [source,xml]
 ----
 <dependency>
-	<groupId>org.springframework.boot</groupId>
-	<artifactId>spring-boot-starter-web</artifactId>
-</dependency>
-<dependency>
 	<groupId>org.springframework.grpc</groupId>
-	<artifactId>spring-grpc-spring-boot-starter</artifactId>
-</dependency>
-<dependency>
-	<groupId>io.grpc</groupId>
-	<artifactId>grpc-servlet-jakarta</artifactId>
+	<artifactId>spring-grpc-server-web-spring-boot-starter</artifactId>
 </dependency>
 ----
 
@@ -82,9 +76,7 @@ For Gradle users
 [source,gradle]
 ----
 dependencies {
-    implementation "org.springframework.boot:spring-boot-starter-web"
-    implementation "org.springframework.grpc:spring-grpc-spring-boot-starter"
-    implementation "io.grpc:grpc-servlet-jakarta"
+    implementation "org.springframework.grpc:spring-grpc-server-web-spring-boot-starter"
 }
 ----
 

--- a/spring-grpc-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-grpc-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -5,27 +5,13 @@
 [[what-s-new-in-0-4-0-since-0-3-0]]
 == What's New in 0.4.0 Since 0.3.0
 
-This section covers the changes made from version 0.2.0 to version 0.3.0.
+This section covers the changes made from version 0.3.0 to version 0.4.0.
 
-=== Channel Factory
-The `GrpcChannelFactory` has a new interface and its methods now return a `Channel` (instead of a `ChannelBuilder`).
-The `createChannel()` method is overloaded with a new method that accepts a `ChannelBuilderOptions` which can be used to configure the channel before it is created.
+=== Fine-grained starter modules
+The following fine-grained Spring Boot starter modules have been added:
 
-=== Client Side Observability
-A gRPC client will generate a new span for each RPC call. The span will be automatically closed when the call is completed.
+- `spring-grpc-client-spring-boot-starter` provides Netty gRPC client
+- `spring-grpc-server-spring-boot-starter` provides Netty gRPC server
+- `spring-grpc-server-spring-boot-starter` provides Servlet gRPC server
 
-=== Security in Servlet Containers
-Spring Security works with gRPC servers running in servlet containers. You can use all your favourite Spring Security features to secure your gRPC services.
-
-[[what-s-new-in-0-3-0-since-0-2-0]]
-== What's New in 0.3.0 Since 0.2.0
-
-This section covers the changes made from version 0.2.0 to version 0.3.0.
-
-=== Client Interceptors
-You can now add xref:client.adoc#client-interceptor[Client Interceptors] to created gRPC channels.
-
-=== Breaking Changes
-
-==== GrpcChannelConfigurer renamed
-The `GrpcChannelConfigurer` has been renamed to `GrpcChannelBuilderCustomizer` to more accurately represent its purpose and be consistent with the server-side terminology.
+The current coarse-grained starter `spring-grpc-spring-boot-starter` still provides Netty gRPC server and client.

--- a/spring-grpc-docs/src/main/antora/modules/ROOT/partials/_configprops.adoc
+++ b/spring-grpc-docs/src/main/antora/modules/ROOT/partials/_configprops.adoc
@@ -40,6 +40,8 @@
 |spring.grpc.server.observations.enabled | `+++true+++` | Whether to enable Observations on the server.
 |spring.grpc.server.port | `+++9090+++` | Server port to listen on. When the value is 0, a random available port is selected. The default is 9090.
 |spring.grpc.server.reflection.enabled | `+++true+++` | Whether to enable Reflection on the gRPC server.
+|spring.grpc.server.security.csrf.enabled | `+++false+++` | Whether to enable CSRF protection on gRPC requests.
+|spring.grpc.server.servlet.enabled | `+++true+++` | Whether to use a servlet server in a servlet-based web application. When the value is false, a native gRPC server will be forced.
 |spring.grpc.server.shutdown-grace-period | `+++30s+++` | Maximum time to wait for the server to gracefully shutdown. When the value is negative, the server waits forever. When the value is 0, the server will force shutdown immediately. The default is 30 seconds.
 |spring.grpc.server.ssl.bundle |  | SSL bundle name.
 |spring.grpc.server.ssl.client-auth | `+++none+++` | Client authentication mode.

--- a/spring-grpc-docs/src/main/antora/modules/ROOT/partials/_configprops.adoc
+++ b/spring-grpc-docs/src/main/antora/modules/ROOT/partials/_configprops.adoc
@@ -40,8 +40,6 @@
 |spring.grpc.server.observations.enabled | `+++true+++` | Whether to enable Observations on the server.
 |spring.grpc.server.port | `+++9090+++` | Server port to listen on. When the value is 0, a random available port is selected. The default is 9090.
 |spring.grpc.server.reflection.enabled | `+++true+++` | Whether to enable Reflection on the gRPC server.
-|spring.grpc.server.security.csrf.enabled | `+++false+++` | Whether to enable CSRF protection on gRPC requests.
-|spring.grpc.server.servlet.enabled | `+++true+++` | Whether to use a servlet server in a servlet-based web application (set to false to force a native gRPC server).
 |spring.grpc.server.shutdown-grace-period | `+++30s+++` | Maximum time to wait for the server to gracefully shutdown. When the value is negative, the server waits forever. When the value is 0, the server will force shutdown immediately. The default is 30 seconds.
 |spring.grpc.server.ssl.bundle |  | SSL bundle name.
 |spring.grpc.server.ssl.client-auth | `+++none+++` | Client authentication mode.

--- a/spring-grpc-server-spring-boot-starter/pom.xml
+++ b/spring-grpc-server-spring-boot-starter/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.grpc</groupId>
+		<artifactId>spring-grpc</artifactId>
+		<version>0.4.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>spring-grpc-server-spring-boot-starter</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring gRPC Server (Netty) Spring Boot Starter</name>
+	<description>Spring gRPC Server (Netty) Spring Boot Starter</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.grpc</groupId>
+			<artifactId>spring-grpc-core</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.grpc</groupId>
+			<artifactId>spring-grpc-spring-boot-autoconfigure</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-netty</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-services</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+			<version>${spring-boot.version}</version>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/spring-grpc-server-web-spring-boot-starter/pom.xml
+++ b/spring-grpc-server-web-spring-boot-starter/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.grpc</groupId>
+		<artifactId>spring-grpc</artifactId>
+		<version>0.4.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>spring-grpc-server-web-spring-boot-starter</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring gRPC Servlet Server Spring Boot Starter</name>
+	<description>Spring gRPC Servlet Server Spring Boot Starter</description>
+
+	<dependencies>
+        <dependency>
+            <groupId>org.springframework.grpc</groupId>
+            <artifactId>spring-grpc-spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-servlet-jakarta</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>${spring-boot.version}</version>
+        </dependency>
+	</dependencies>
+
+</project>

--- a/spring-grpc-server-web-spring-boot-starter/pom.xml
+++ b/spring-grpc-server-web-spring-boot-starter/pom.xml
@@ -14,19 +14,19 @@
 	<description>Spring gRPC Servlet Server Spring Boot Starter</description>
 
 	<dependencies>
-        <dependency>
-            <groupId>org.springframework.grpc</groupId>
-            <artifactId>spring-grpc-spring-boot-starter</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-servlet-jakarta</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-            <version>${spring-boot.version}</version>
-        </dependency>
+		<dependency>
+			<groupId>org.springframework.grpc</groupId>
+			<artifactId>spring-grpc-spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-servlet-jakarta</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+			<version>${spring-boot.version}</version>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/spring-grpc-spring-boot-autoconfigure/pom.xml
+++ b/spring-grpc-spring-boot-autoconfigure/pom.xml
@@ -75,6 +75,11 @@
 		</dependency>
         <dependency>
             <groupId>io.grpc</groupId>
+            <artifactId>grpc-stub</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
             <artifactId>grpc-netty</artifactId>
             <optional>true</optional>
         </dependency>

--- a/spring-grpc-spring-boot-autoconfigure/pom.xml
+++ b/spring-grpc-spring-boot-autoconfigure/pom.xml
@@ -51,6 +51,7 @@
 			<groupId>org.springframework.grpc</groupId>
 			<artifactId>spring-grpc-core</artifactId>
 			<version>${project.version}</version>
+            <optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -72,6 +73,11 @@
 			<artifactId>grpc-services</artifactId>
 			<optional>true</optional>
 		</dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty</artifactId>
+            <optional>true</optional>
+        </dependency>
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-netty-shaded</artifactId>

--- a/spring-grpc-spring-boot-autoconfigure/pom.xml
+++ b/spring-grpc-spring-boot-autoconfigure/pom.xml
@@ -51,7 +51,7 @@
 			<groupId>org.springframework.grpc</groupId>
 			<artifactId>spring-grpc-core</artifactId>
 			<version>${project.version}</version>
-            <optional>true</optional>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -73,16 +73,16 @@
 			<artifactId>grpc-services</artifactId>
 			<optional>true</optional>
 		</dependency>
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-stub</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-netty</artifactId>
-            <optional>true</optional>
-        </dependency>
+		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-stub</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-netty</artifactId>
+			<optional>true</optional>
+		</dependency>
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-netty-shaded</artifactId>

--- a/spring-grpc-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-grpc-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -26,7 +26,7 @@
     {
       "name": "spring.grpc.server.servlet.enabled",
       "type": "java.lang.Boolean",
-      "description": "Whether to use a servlet server in a servlet-based web application (set to false to force a native gRPC server).",
+      "description": "Whether to use a servlet server in a servlet-based web application. When the value is false, a native gRPC server will be forced.",
       "defaultValue": true
     },
     {

--- a/spring-grpc-spring-boot-starter/pom.xml
+++ b/spring-grpc-spring-boot-starter/pom.xml
@@ -24,15 +24,15 @@
 			<artifactId>spring-grpc-spring-boot-autoconfigure</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-netty</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-services</artifactId>
-            <optional>true</optional>
-        </dependency>
+		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-netty</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-services</artifactId>
+			<optional>true</optional>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter</artifactId>

--- a/spring-grpc-spring-boot-starter/pom.xml
+++ b/spring-grpc-spring-boot-starter/pom.xml
@@ -10,33 +10,17 @@
 	</parent>
 	<artifactId>spring-grpc-spring-boot-starter</artifactId>
 	<packaging>jar</packaging>
-	<name>Spring gRPC Server Spring Boot Starter</name>
-	<description>Spring gRPC Server Spring Boot Starter</description>
+	<name>Spring gRPC Server and Client Spring Boot Starter</name>
+	<description>Spring gRPC Server and Client Spring Boot Starter</description>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.grpc</groupId>
-			<artifactId>spring-grpc-core</artifactId>
-			<version>${project.version}</version>
+			<artifactId>spring-grpc-client-spring-boot-starter</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.grpc</groupId>
-			<artifactId>spring-grpc-spring-boot-autoconfigure</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>io.grpc</groupId>
-			<artifactId>grpc-netty</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>io.grpc</groupId>
-			<artifactId>grpc-services</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
-			<version>${spring-boot.version}</version>
+			<artifactId>spring-grpc-server-spring-boot-starter</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/spring-grpc-spring-boot-starter/pom.xml
+++ b/spring-grpc-spring-boot-starter/pom.xml
@@ -24,6 +24,10 @@
 			<artifactId>spring-grpc-spring-boot-autoconfigure</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty</artifactId>
+        </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter</artifactId>

--- a/spring-grpc-test/pom.xml
+++ b/spring-grpc-test/pom.xml
@@ -25,6 +25,11 @@
 	</properties>
 
 	<dependencies>
+        <dependency>
+            <groupId>org.springframework.grpc</groupId>
+            <artifactId>spring-grpc-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 		<dependency>
 			<groupId>org.springframework.grpc</groupId>
 			<artifactId>spring-grpc-spring-boot-autoconfigure</artifactId>
@@ -39,6 +44,11 @@
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-testing</artifactId>
 		</dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty</artifactId>
+            <optional>true</optional>
+        </dependency>
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-inprocess</artifactId>

--- a/spring-grpc-test/pom.xml
+++ b/spring-grpc-test/pom.xml
@@ -25,11 +25,11 @@
 	</properties>
 
 	<dependencies>
-        <dependency>
-            <groupId>org.springframework.grpc</groupId>
-            <artifactId>spring-grpc-core</artifactId>
-            <version>${project.version}</version>
-        </dependency>
+		<dependency>
+			<groupId>org.springframework.grpc</groupId>
+			<artifactId>spring-grpc-core</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.grpc</groupId>
 			<artifactId>spring-grpc-spring-boot-autoconfigure</artifactId>
@@ -44,11 +44,11 @@
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-testing</artifactId>
 		</dependency>
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-netty</artifactId>
-            <optional>true</optional>
-        </dependency>
+		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-netty</artifactId>
+			<optional>true</optional>
+		</dependency>
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-inprocess</artifactId>


### PR DESCRIPTION
This PR does the following:

- Makes `grpc-netty` optional and leaves the opinion to the starter
- Cleans up dependencies so that no opinion on choice of server is made until the starter modules
- Adds the following fine-grained starters:
  - Netty client starter
  - Netty server starter
  - Servlet server starter
- Current coarse-grained starter points to newly added client + server starters
- Updates Tomcat samples to use new servlet server starter
