### PR TITLE
Add config prop metadata and remove not-needed property

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -25,7 +25,7 @@ jobs:
           ./mvnw -B clean install
       - name: Capture Test Results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: '*/target/surefire-reports/*.*'

--- a/spring-grpc-docs/src/main/antora/modules/ROOT/pages/server.adoc
+++ b/spring-grpc-docs/src/main/antora/modules/ROOT/pages/server.adoc
@@ -266,8 +266,8 @@ public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Excepti
 }
 ----
 
-By default CSRF protection is automatically disabled for gRPC requests because it is incompatible with the protocol.
-You can switch off that behaviour and configure your own CSRF protection if you want to by explicitly setting `spring.grpc.security.csrf.enabled=true`.
+By default, CSRF protection is automatically disabled for gRPC requests because it is incompatible with the protocol.
+You can switch off that behaviour and configure your own CSRF protection if you want to by explicitly setting `spring.grpc.server.security.csrf.enabled=true`.
 A servlet application that exposes gRPC endpoints on a different port (with `spring.grpc.server.servlet.enabled=false`) will also not have CSRF protection disabled by default.
 
 === Securing Individual Methods

--- a/spring-grpc-docs/src/main/antora/modules/ROOT/partials/_configprops.adoc
+++ b/spring-grpc-docs/src/main/antora/modules/ROOT/partials/_configprops.adoc
@@ -19,7 +19,6 @@
 |spring.grpc.client.default-channel.ssl.enabled |  | Whether to enable SSL support. Enabled automatically if "bundle" is provided unless specified otherwise.
 |spring.grpc.client.default-channel.user-agent |  | The custom User-Agent for the channel.
 |spring.grpc.client.observations.enabled | `+++true+++` | Whether to enable Observations on the client.
-|spring.grpc.security.csrf.enabled | `+++false+++` | Whether to enable CSRF protection on gRPC requests.
 |spring.grpc.server.address |  | The address to bind to. could be a host:port combination or a pseudo URL like static://host:port. Can not be set if host or port are set independently.
 |spring.grpc.server.exception-handling.enabled | `+++true+++` | Whether to enable user-defined global exception handling on the gRPC server.
 |spring.grpc.server.health.actuator.enabled | `+++true+++` | Whether to adapt Actuator health indicators into gRPC health checks.
@@ -41,6 +40,7 @@
 |spring.grpc.server.observations.enabled | `+++true+++` | Whether to enable Observations on the server.
 |spring.grpc.server.port | `+++9090+++` | Server port to listen on. When the value is 0, a random available port is selected. The default is 9090.
 |spring.grpc.server.reflection.enabled | `+++true+++` | Whether to enable Reflection on the gRPC server.
+|spring.grpc.server.security.csrf.enabled | `+++false+++` | Whether to enable CSRF protection on gRPC requests.
 |spring.grpc.server.servlet.enabled | `+++true+++` | Whether to use a servlet server in a servlet-based web application (set to false to force a native gRPC server).
 |spring.grpc.server.shutdown-grace-period | `+++30s+++` | Maximum time to wait for the server to gracefully shutdown. When the value is negative, the server waits forever. When the value is 0, the server will force shutdown immediately. The default is 30 seconds.
 |spring.grpc.server.ssl.bundle |  | SSL bundle name.

--- a/spring-grpc-docs/src/main/antora/modules/ROOT/partials/_configprops.adoc
+++ b/spring-grpc-docs/src/main/antora/modules/ROOT/partials/_configprops.adoc
@@ -2,48 +2,50 @@
 |Name | Default | Description
 
 |spring.grpc.client.channels |  | Map of channels configured by name.
-|spring.grpc.client.default-channel.address |  | The target address uri to connect to.
-|spring.grpc.client.default-channel.default-load-balancing-policy |  | The default load balancing policy the channel should use.
-|spring.grpc.client.default-channel.enable-keep-alive |  | Whether keep alive is enabled on the channel.
-|spring.grpc.client.default-channel.health.enabled |  | Whether to enable client-side health check for the channel.
+|spring.grpc.client.default-channel.address | `+++static://localhost:9090+++` | The target address uri to connect to.
+|spring.grpc.client.default-channel.default-load-balancing-policy | `+++round_robin+++` | The default load balancing policy the channel should use.
+|spring.grpc.client.default-channel.enable-keep-alive | `+++false+++` | Whether keep alive is enabled on the channel.
+|spring.grpc.client.default-channel.health.enabled | `+++false+++` | Whether to enable client-side health check for the channel.
 |spring.grpc.client.default-channel.health.service-name |  | Name of the service to check health on.
-|spring.grpc.client.default-channel.idle-timeout |  | The duration without ongoing RPCs before going to idle mode.
-|spring.grpc.client.default-channel.keep-alive-time |  | The delay before sending a keepAlive. Note that shorter intervals increase the network burden for the server and this value can not be lower than 'permitKeepAliveTime' on the server.
-|spring.grpc.client.default-channel.keep-alive-timeout |  | The default timeout for a keepAlives ping request.
-|spring.grpc.client.default-channel.keep-alive-without-calls |  | Whether a keepAlive will be performed when there are no outstanding RPC on a connection.
-|spring.grpc.client.default-channel.max-inbound-message-size |  | Maximum message size allowed to be received by the channel (default 4MiB). Set to '-1' to use the highest possible limit (not recommended).
-|spring.grpc.client.default-channel.max-inbound-metadata-size |  | Maximum metadata size allowed to be received by the channel (default 8KiB). Set to '-1' to use the highest possible limit (not recommended).
-|spring.grpc.client.default-channel.negotiation-type |  | The negotiation type for the channel.
-|spring.grpc.client.default-channel.secure |  | Flag to say that strict SSL checks are not enabled (so the remote certificate could be anonymous).
+|spring.grpc.client.default-channel.idle-timeout | `+++20s+++` | The duration without ongoing RPCs before going to idle mode.
+|spring.grpc.client.default-channel.keep-alive-time | `+++5m+++` | The delay before sending a keepAlive. Note that shorter intervals increase the network burden for the server and this value can not be lower than 'permitKeepAliveTime' on the server.
+|spring.grpc.client.default-channel.keep-alive-timeout | `+++20s+++` | The default timeout for a keepAlives ping request.
+|spring.grpc.client.default-channel.keep-alive-without-calls | `+++false+++` | Whether a keepAlive will be performed when there are no outstanding RPC on a connection.
+|spring.grpc.client.default-channel.max-inbound-message-size | `+++4194304B+++` | Maximum message size allowed to be received by the channel (default 4MiB). Set to '-1' to use the highest possible limit (not recommended).
+|spring.grpc.client.default-channel.max-inbound-metadata-size | `+++8192B+++` | Maximum metadata size allowed to be received by the channel (default 8KiB). Set to '-1' to use the highest possible limit (not recommended).
+|spring.grpc.client.default-channel.negotiation-type | `+++plaintext+++` | The negotiation type for the channel.
+|spring.grpc.client.default-channel.secure | `+++true+++` | Flag to say that strict SSL checks are not enabled (so the remote certificate could be anonymous).
 |spring.grpc.client.default-channel.ssl.bundle |  | SSL bundle name.
 |spring.grpc.client.default-channel.ssl.enabled |  | Whether to enable SSL support. Enabled automatically if "bundle" is provided unless specified otherwise.
 |spring.grpc.client.default-channel.user-agent |  | The custom User-Agent for the channel.
 |spring.grpc.client.observations.enabled | `+++true+++` | Whether to enable Observations on the client.
+|spring.grpc.security.csrf.enabled | `+++false+++` | Whether to enable CSRF protection on gRPC requests.
 |spring.grpc.server.address |  | The address to bind to. could be a host:port combination or a pseudo URL like static://host:port. Can not be set if host or port are set independently.
 |spring.grpc.server.exception-handling.enabled | `+++true+++` | Whether to enable user-defined global exception handling on the gRPC server.
-|spring.grpc.server.health.actuator.enabled |  | Whether to adapt Actuator health indicators into gRPC health checks.
+|spring.grpc.server.health.actuator.enabled | `+++true+++` | Whether to adapt Actuator health indicators into gRPC health checks.
 |spring.grpc.server.health.actuator.health-indicator-paths |  | List of Actuator health indicator paths to adapt into gRPC health checks.
-|spring.grpc.server.health.actuator.update-initial-delay |  | The initial delay before updating the health status the very first time.
-|spring.grpc.server.health.actuator.update-overall-health |  | Whether to update the overall gRPC server health (the '' service) with the aggregate status of the configured health indicators.
-|spring.grpc.server.health.actuator.update-rate |  | How often to update the health status.
-|spring.grpc.server.health.enabled |  | Whether to auto-configure Health feature on the gRPC server.
-|spring.grpc.server.host |  | Server address to bind to. The default is any IP address ('*').
+|spring.grpc.server.health.actuator.update-initial-delay | `+++5s+++` | The initial delay before updating the health status the very first time.
+|spring.grpc.server.health.actuator.update-overall-health | `+++true+++` | Whether to update the overall gRPC server health (the '' service) with the aggregate status of the configured health indicators.
+|spring.grpc.server.health.actuator.update-rate | `+++5s+++` | How often to update the health status.
+|spring.grpc.server.health.enabled | `+++true+++` | Whether to auto-configure Health feature on the gRPC server.
+|spring.grpc.server.host | `+++*+++` | Server address to bind to. The default is any IP address ('*').
 |spring.grpc.server.keep-alive.max-age |  | Maximum time a connection may exist before being gracefully terminated (default infinite).
 |spring.grpc.server.keep-alive.max-age-grace |  | Maximum time for graceful connection termination (default infinite).
 |spring.grpc.server.keep-alive.max-idle |  | Maximum time a connection can remain idle before being gracefully terminated (default infinite).
-|spring.grpc.server.keep-alive.permit-time |  | Maximum keep-alive time clients are permitted to configure (default 5m).
-|spring.grpc.server.keep-alive.permit-without-calls |  | Whether clients are permitted to send keep alive pings when there are no outstanding RPCs on the connection (default false).
-|spring.grpc.server.keep-alive.time |  | Duration without read activity before sending a keep alive ping (default 2h).
-|spring.grpc.server.keep-alive.timeout |  | Maximum time to wait for read activity after sending a keep alive ping. If sender does not receive an acknowledgment within this time, it will close the connection (default 20s).
-|spring.grpc.server.max-inbound-message-size |  | Maximum message size allowed to be received by the server (default 4MiB).
-|spring.grpc.server.max-inbound-metadata-size |  | Maximum metadata size allowed to be received by the server (default 8KiB).
+|spring.grpc.server.keep-alive.permit-time | `+++5m+++` | Maximum keep-alive time clients are permitted to configure (default 5m).
+|spring.grpc.server.keep-alive.permit-without-calls | `+++false+++` | Whether clients are permitted to send keep alive pings when there are no outstanding RPCs on the connection (default false).
+|spring.grpc.server.keep-alive.time | `+++2h+++` | Duration without read activity before sending a keep alive ping (default 2h).
+|spring.grpc.server.keep-alive.timeout | `+++20s+++` | Maximum time to wait for read activity after sending a keep alive ping. If sender does not receive an acknowledgment within this time, it will close the connection (default 20s).
+|spring.grpc.server.max-inbound-message-size | `+++4194304B+++` | Maximum message size allowed to be received by the server (default 4MiB).
+|spring.grpc.server.max-inbound-metadata-size | `+++8192B+++` | Maximum metadata size allowed to be received by the server (default 8KiB).
 |spring.grpc.server.observations.enabled | `+++true+++` | Whether to enable Observations on the server.
 |spring.grpc.server.port | `+++9090+++` | Server port to listen on. When the value is 0, a random available port is selected. The default is 9090.
 |spring.grpc.server.reflection.enabled | `+++true+++` | Whether to enable Reflection on the gRPC server.
-|spring.grpc.server.shutdown-grace-period |  | Maximum time to wait for the server to gracefully shutdown. When the value is negative, the server waits forever. When the value is 0, the server will force shutdown immediately. The default is 30 seconds.
+|spring.grpc.server.servlet.enabled | `+++true+++` | Whether to use a servlet server in a servlet-based web application (set to false to force a native gRPC server).
+|spring.grpc.server.shutdown-grace-period | `+++30s+++` | Maximum time to wait for the server to gracefully shutdown. When the value is negative, the server waits forever. When the value is 0, the server will force shutdown immediately. The default is 30 seconds.
 |spring.grpc.server.ssl.bundle |  | SSL bundle name.
-|spring.grpc.server.ssl.client-auth |  | Client authentication mode.
+|spring.grpc.server.ssl.client-auth | `+++none+++` | Client authentication mode.
 |spring.grpc.server.ssl.enabled |  | Whether to enable SSL support. Enabled automatically if "bundle" is provided unless specified otherwise.
-|spring.grpc.server.ssl.secure |  | Flag to indicate that client authentication is secure (i.e. certificates are checked). Do not set this to false in production.
+|spring.grpc.server.ssl.secure | `+++true+++` | Flag to indicate that client authentication is secure (i.e. certificates are checked). Do not set this to false in production.
 
 |===

--- a/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/server/GrpcServerFactoryAutoConfiguration.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/server/GrpcServerFactoryAutoConfiguration.java
@@ -140,8 +140,6 @@ public class GrpcServerFactoryAutoConfiguration {
 		}
 
 		@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.REACTIVE)
-		@ConditionalOnProperty(prefix = "spring.grpc.server", name = "reactive.enabled", havingValue = "false",
-				matchIfMissing = false)
 		static class OnExplicitlyDisabledWebflux {
 
 		}

--- a/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/server/security/GrpcDisableCsrfHttpConfigurer.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/server/security/GrpcDisableCsrfHttpConfigurer.java
@@ -25,8 +25,8 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
  * <p>
  * This configurer checks the application context to determine if CSRF protection should
  * be disabled for gRPC requests based on the property
- * {@code spring.grpc.security.csrf.enabled}. By default, CSRF protection is disabled
- * unless explicitly enabled in the application properties.
+ * {@code spring.grpc.server.security.csrf.enabled}. By default, CSRF protection is
+ * disabled unless explicitly enabled in the application properties.
  * </p>
  *
  * @see AbstractHttpConfigurer
@@ -45,7 +45,8 @@ public class GrpcDisableCsrfHttpConfigurer extends AbstractHttpConfigurer<GrpcDi
 
 	private boolean isServletEnabledAndCsrfDisabled(ApplicationContext context) {
 		return context.getEnvironment().getProperty("spring.grpc.server.servlet.enabled", Boolean.class, true)
-				&& !context.getEnvironment().getProperty("spring.grpc.security.csrf.enabled", Boolean.class, false);
+				&& !context.getEnvironment()
+					.getProperty("spring.grpc.server.security.csrf.enabled", Boolean.class, false);
 	}
 
 }

--- a/spring-grpc-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-grpc-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -2,12 +2,6 @@
   "groups": [],
   "properties": [
     {
-      "name": "spring.grpc.security.csrf.enabled",
-      "type": "java.lang.Boolean",
-      "description": "Whether to enable CSRF protection on gRPC requests.",
-      "defaultValue": false
-    },
-    {
       "name": "spring.grpc.server.port",
       "defaultValue": "9090"
     },
@@ -22,6 +16,12 @@
       "type": "java.lang.Boolean",
       "description": "Whether to enable user-defined global exception handling on the gRPC server.",
       "defaultValue": true
+    },
+    {
+      "name": "spring.grpc.server.security.csrf.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether to enable CSRF protection on gRPC requests.",
+      "defaultValue": false
     },
     {
       "name": "spring.grpc.server.servlet.enabled",

--- a/spring-grpc-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-grpc-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -2,6 +2,12 @@
   "groups": [],
   "properties": [
     {
+      "name": "spring.grpc.security.csrf.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether to enable CSRF protection on gRPC requests.",
+      "defaultValue": false
+    },
+    {
       "name": "spring.grpc.server.port",
       "defaultValue": "9090"
     },
@@ -15,6 +21,12 @@
       "name": "spring.grpc.server.exception-handling.enabled",
       "type": "java.lang.Boolean",
       "description": "Whether to enable user-defined global exception handling on the gRPC server.",
+      "defaultValue": true
+    },
+    {
+      "name": "spring.grpc.server.servlet.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether to use a servlet server in a servlet-based web application (set to false to force a native gRPC server).",
       "defaultValue": true
     },
     {


### PR DESCRIPTION
- Adds a couple missing entries to additional-spring-configuration-metadata.json.

- Removes not-needed conditional property guard for `spring.grpc.server.reactive.enabled`