### PR TITLE
Generate config props during doc phase

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
         echo BUILD_VERSION=$BUILD_VERSION >> $GITHUB_ENV
     - name: Run Antora
       run: |
-        ./mvnw -pl spring-grpc-docs antora
+        ./mvnw -pl spring-grpc-docs process-resources antora -P docs
     - name: Publish Docs
       uses: spring-io/spring-doc-actions/rsync-antora-reference@v0.0.11
       with:

--- a/spring-grpc-docs/pom.xml
+++ b/spring-grpc-docs/pom.xml
@@ -100,30 +100,6 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>exec-maven-plugin</artifactId>
-				<version>${maven-exec-plugin.version}</version>
-				<executions>
-					<execution>
-						<id>generate-configprops</id>
-						<phase>package</phase>
-						<goals>
-							<goal>java</goal>
-						</goals>
-						<configuration>
-							<includeProjectDependencies>true</includeProjectDependencies>
-							<includePluginDependencies>false</includePluginDependencies>
-							<mainClass>
-								org.springframework.grpc.internal.ConfigurationPropertiesAsciidocGenerator</mainClass>
-							<arguments>
-								<argument>${configprops.path}</argument>
-								<argument>${configprops.inclusionPattern}</argument>
-							</arguments>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>org.jruby.maven</groupId>
 				<artifactId>gem-maven-plugin</artifactId>
 				<version>${maven-gem-plugin.version}</version>
@@ -208,6 +184,43 @@
 			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>docs</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>exec-maven-plugin</artifactId>
+						<version>${maven-exec-plugin.version}</version>
+						<executions>
+							<execution>
+								<id>generate-configprops</id>
+								<phase>process-resources</phase>
+								<goals>
+									<goal>java</goal>
+								</goals>
+								<configuration>
+									<includeProjectDependencies>true</includeProjectDependencies>
+									<includePluginDependencies>false</includePluginDependencies>
+									<mainClass>
+										org.springframework.grpc.internal.ConfigurationPropertiesAsciidocGenerator</mainClass>
+									<arguments>
+										<argument>${configprops.path}</argument>
+										<argument>${configprops.inclusionPattern}</argument>
+									</arguments>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 
 	<repositories>
 		<repository>


### PR DESCRIPTION
I suppose the main problem is that we should not generate documentation at `mvn:install/package`, so if I assume correctly, then we should delegate documentation generation to `mvn:site`. Then the documentation will be generated only when `mvn:site` is activated.

Fix #109 

