### PR TITLE
Fix typo in pom.xml in core module

### DIFF
--- a/spring-grpc-core/pom.xml
+++ b/spring-grpc-core/pom.xml
@@ -11,7 +11,7 @@
 	<artifactId>spring-grpc-core</artifactId>
 	<packaging>jar</packaging>
 	<name>Spring gRPC Core</name>
-	<description>Core domgrpcn for gRPC programming</description>
+	<description>Core module for gRPC programming</description>
 	<url>https://github.com/spring-projects-experimental/spring-grpc</url>
 
 	<scm>


### PR DESCRIPTION
I'm not quite sure if `domgrpcn` makes any sense, so I assumed there was a typo here. I guess in our context `module` would be fine?