### PR TITLE
Add spring-grpc-bom module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,6 @@
 	<description>Building gRPC applications with Spring Boot</description>
 
 	<modules>
-		<module>spring-grpc-docs</module>
-		<module>spring-grpc-dependencies</module>
 		<module>spring-grpc-core</module>
 		<module>spring-grpc-test</module>
 		<module>spring-grpc-spring-boot-autoconfigure</module>
@@ -23,6 +21,9 @@
 		<module>spring-grpc-client-spring-boot-starter</module>
 		<module>spring-grpc-server-spring-boot-starter</module>
 		<module>spring-grpc-server-web-spring-boot-starter</module>
+		<module>spring-grpc-bom</module>
+		<module>spring-grpc-dependencies</module>
+		<module>spring-grpc-docs</module>
 		<module>samples</module>
 	</modules>
 

--- a/samples/grpc-oauth2/build.gradle
+++ b/samples/grpc-oauth2/build.gradle
@@ -24,7 +24,7 @@ repositories {
 
 dependencyManagement {
 	imports {
-		mavenBom 'org.springframework.grpc:spring-grpc-dependencies:0.4.0-SNAPSHOT'
+		mavenBom 'org.springframework.grpc:spring-grpc-bom:0.4.0-SNAPSHOT'
 	}
 }
 

--- a/samples/grpc-oauth2/pom.xml
+++ b/samples/grpc-oauth2/pom.xml
@@ -39,7 +39,7 @@
 		<dependencies>
 			<dependency>
 				<groupId>org.springframework.grpc</groupId>
-				<artifactId>spring-grpc-dependencies</artifactId>
+				<artifactId>spring-grpc-bom</artifactId>
 				<version>0.4.0-SNAPSHOT</version>
 				<type>pom</type>
 				<scope>import</scope>

--- a/samples/grpc-reactive/build.gradle
+++ b/samples/grpc-reactive/build.gradle
@@ -24,7 +24,7 @@ repositories {
 
 dependencyManagement {
     imports {
-        mavenBom 'org.springframework.grpc:spring-grpc-dependencies:0.4.0-SNAPSHOT'
+        mavenBom 'org.springframework.grpc:spring-grpc-bom:0.4.0-SNAPSHOT'
     }
 }
 

--- a/samples/grpc-reactive/pom.xml
+++ b/samples/grpc-reactive/pom.xml
@@ -37,7 +37,7 @@
 		<dependencies>
 			<dependency>
 				<groupId>org.springframework.grpc</groupId>
-				<artifactId>spring-grpc-dependencies</artifactId>
+				<artifactId>spring-grpc-bom</artifactId>
 				<version>0.4.0-SNAPSHOT</version>
 				<type>pom</type>
 				<scope>import</scope>

--- a/samples/grpc-secure/build.gradle
+++ b/samples/grpc-secure/build.gradle
@@ -24,7 +24,7 @@ repositories {
 
 dependencyManagement {
 	imports {
-		mavenBom 'org.springframework.grpc:spring-grpc-dependencies:0.4.0-SNAPSHOT'
+		mavenBom 'org.springframework.grpc:spring-grpc-bom:0.4.0-SNAPSHOT'
 	}
 }
 

--- a/samples/grpc-secure/pom.xml
+++ b/samples/grpc-secure/pom.xml
@@ -37,7 +37,7 @@
 		<dependencies>
 			<dependency>
 				<groupId>org.springframework.grpc</groupId>
-				<artifactId>spring-grpc-dependencies</artifactId>
+				<artifactId>spring-grpc-bom</artifactId>
 				<version>0.4.0-SNAPSHOT</version>
 				<type>pom</type>
 				<scope>import</scope>

--- a/samples/grpc-server-netty-shaded/build.gradle
+++ b/samples/grpc-server-netty-shaded/build.gradle
@@ -24,7 +24,7 @@ repositories {
 
 dependencyManagement {
     imports {
-        mavenBom 'org.springframework.grpc:spring-grpc-dependencies:0.4.0-SNAPSHOT'
+        mavenBom 'org.springframework.grpc:spring-grpc-bom:0.4.0-SNAPSHOT'
     }
 }
 

--- a/samples/grpc-server-netty-shaded/pom.xml
+++ b/samples/grpc-server-netty-shaded/pom.xml
@@ -24,7 +24,7 @@
 		<dependencies>
 			<dependency>
 				<groupId>org.springframework.grpc</groupId>
-				<artifactId>spring-grpc-dependencies</artifactId>
+				<artifactId>spring-grpc-bom</artifactId>
 				<version>0.4.0-SNAPSHOT</version>
 				<type>pom</type>
 				<scope>import</scope>

--- a/samples/grpc-server/build.gradle
+++ b/samples/grpc-server/build.gradle
@@ -24,7 +24,7 @@ repositories {
 
 dependencyManagement {
     imports {
-        mavenBom 'org.springframework.grpc:spring-grpc-dependencies:0.4.0-SNAPSHOT'
+        mavenBom 'org.springframework.grpc:spring-grpc-bom:0.4.0-SNAPSHOT'
     }
 }
 

--- a/samples/grpc-server/pom.xml
+++ b/samples/grpc-server/pom.xml
@@ -37,7 +37,7 @@
 		<dependencies>
 			<dependency>
 				<groupId>org.springframework.grpc</groupId>
-				<artifactId>spring-grpc-dependencies</artifactId>
+				<artifactId>spring-grpc-bom</artifactId>
 				<version>0.4.0-SNAPSHOT</version>
 				<type>pom</type>
 				<scope>import</scope>

--- a/samples/grpc-tomcat-secure/pom.xml
+++ b/samples/grpc-tomcat-secure/pom.xml
@@ -37,7 +37,7 @@
 		<dependencies>
 			<dependency>
 				<groupId>org.springframework.grpc</groupId>
-				<artifactId>spring-grpc-dependencies</artifactId>
+				<artifactId>spring-grpc-bom</artifactId>
 				<version>0.4.0-SNAPSHOT</version>
 				<type>pom</type>
 				<scope>import</scope>

--- a/samples/grpc-tomcat/pom.xml
+++ b/samples/grpc-tomcat/pom.xml
@@ -37,7 +37,7 @@
 		<dependencies>
 			<dependency>
 				<groupId>org.springframework.grpc</groupId>
-				<artifactId>spring-grpc-dependencies</artifactId>
+				<artifactId>spring-grpc-bom</artifactId>
 				<version>0.4.0-SNAPSHOT</version>
 				<type>pom</type>
 				<scope>import</scope>

--- a/samples/grpc-webflux/build.gradle
+++ b/samples/grpc-webflux/build.gradle
@@ -24,7 +24,7 @@ repositories {
 
 dependencyManagement {
     imports {
-        mavenBom 'org.springframework.grpc:spring-grpc-dependencies:0.4.0-SNAPSHOT'
+        mavenBom 'org.springframework.grpc:spring-grpc-bom:0.4.0-SNAPSHOT'
     }
 }
 

--- a/samples/grpc-webflux/pom.xml
+++ b/samples/grpc-webflux/pom.xml
@@ -37,7 +37,7 @@
 		<dependencies>
 			<dependency>
 				<groupId>org.springframework.grpc</groupId>
-				<artifactId>spring-grpc-dependencies</artifactId>
+				<artifactId>spring-grpc-bom</artifactId>
 				<version>0.4.0-SNAPSHOT</version>
 				<type>pom</type>
 				<scope>import</scope>

--- a/spring-grpc-bom/pom.xml
+++ b/spring-grpc-bom/pom.xml
@@ -5,12 +5,12 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.grpc</groupId>
-	<artifactId>spring-grpc-dependencies</artifactId>
+	<artifactId>spring-grpc-bom</artifactId>
 	<version>0.4.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
-	<name>Spring gRPC dependencies</name>
-	<description>Dependencies for the Spring gRPC modules</description>
+	<name>Spring gRPC (Bill of Materials)</name>
+	<description>Bill of Materials for the Spring gRPC modules</description>
 
 	<url>https://github.com/spring-projects-experimental/spring-grpc</url>
 
@@ -49,10 +49,9 @@
 	</licenses>
 
 	<properties>
-		<spring-framework.version>6.2.3</spring-framework.version>
-		<spring-security.version>6.4.2</spring-security.version>
-		<micrometer.version>1.13.6</micrometer.version>
-		<netty.version>4.1.118.Final</netty.version>
+		<grpc.version>1.70.0</grpc.version>
+		<protobuf-java.version>3.25.6</protobuf-java.version>
+		<google-common-protos.version>2.46.0</google-common-protos.version>
 		<spring-javaformat-maven-plugin.version>0.0.43</spring-javaformat-maven-plugin.version>
 	</properties>
 
@@ -60,31 +59,62 @@
 		<dependencies>
 			<dependency>
 				<groupId>org.springframework.grpc</groupId>
-				<artifactId>spring-grpc-bom</artifactId>
+				<artifactId>spring-grpc-core</artifactId>
 				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.grpc</groupId>
+				<artifactId>spring-grpc-spring-boot-autoconfigure</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.grpc</groupId>
+				<artifactId>spring-grpc-spring-boot-starter</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.grpc</groupId>
+				<artifactId>spring-grpc-client-spring-boot-starter</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.grpc</groupId>
+				<artifactId>spring-grpc-server-spring-boot-starter</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.grpc</groupId>
+				<artifactId>spring-grpc-server-web-spring-boot-starter</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.grpc</groupId>
+				<artifactId>spring-grpc-test</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.grpc</groupId>
+				<artifactId>grpc-bom</artifactId>
+				<version>${grpc.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
 			<dependency>
-				<groupId>org.springframework</groupId>
-				<artifactId>spring-framework-bom</artifactId>
-				<version>${spring-framework.version}</version>
+				<groupId>com.google.protobuf</groupId>
+				<artifactId>protobuf-bom</artifactId>
+				<version>${protobuf-java.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
 			<dependency>
-				<groupId>org.springframework.security</groupId>
-				<artifactId>spring-security-bom</artifactId>
-				<version>${spring-security.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
+				<groupId>com.google.protobuf</groupId>
+				<artifactId>protoc</artifactId>
+				<version>${protobuf-java.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>io.netty</groupId>
-				<artifactId>netty-bom</artifactId>
-				<version>${netty.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
+				<groupId>com.google.api.grpc</groupId>
+				<artifactId>proto-google-common-protos</artifactId>
+				<version>${google-common-protos.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-grpc-docs/src/main/antora/modules/ROOT/pages/getting-started.adoc
+++ b/spring-grpc-docs/src/main/antora/modules/ROOT/pages/getting-started.adoc
@@ -185,10 +185,17 @@ repositories {
 [[dependency-management]]
 === Dependency Management
 
-The Spring gRPC Dependencies declares the recommended versions of all the dependencies used by a given release of Spring gRPC.
-Using the dependencies from your application’s build script avoids the need for you to specify and maintain the dependency versions yourself.
-Instead, the version you’re using determines the utilized dependency versions.
+The `spring-grpc-bom` artifact declares the recommended versions of the dependencies used by a given release of Spring gRPC, excluding dependencies already managed by Spring Boot dependency management.
+
+The `spring-grpc-dependencies` artifact declares the recommended versions of all the dependencies used by a given release of Spring gRPC, including dependencies already managed by Spring Boot dependency management.
+
+If you are running Spring gRPC in a Spring Boot application then use `spring-grpc-bom`, otherwise use `spring-grpc-dependencies`.
+
+Using one of these dependency modules avoids the need for you to specify and maintain the dependency versions yourself.
+Instead, the version of the dependency module you are using determines the utilized dependency versions.
 It also ensures that you’re using supported and tested versions of the dependencies by default, unless you choose to override them.
+
+NOTE: The examples below assume you are running inside a Spring Boot application and therefore use `spring-grpc-bom`.
 
 If you’re a Maven user, you can use the dependencies by adding the following to your pom.xml file -
 
@@ -198,7 +205,7 @@ If you’re a Maven user, you can use the dependencies by adding the following t
     <dependencies>
         <dependency>
             <groupId>org.springframework.grpc</groupId>
-            <artifactId>spring-grpc-dependencies</artifactId>
+            <artifactId>spring-grpc-bom</artifactId>
             <version>0.4.0-SNAPSHOT</version>
             <type>pom</type>
             <scope>import</scope>
@@ -207,14 +214,14 @@ If you’re a Maven user, you can use the dependencies by adding the following t
 </dependencyManagement>
 ----
 
-Gradle users can also use the Spring gRPC Dependencies by leveraging Gradle (5.0+) native support for declaring dependency constraints using a Maven BOM.
+Gradle users can also use the dependencies by leveraging Gradle (5.0+) native support for declaring dependency constraints using a Maven BOM.
 This is implemented by adding a 'platform' dependency handler method to the dependencies section of your Gradle build script.
 As shown in the snippet below this can then be followed by version-less declarations of the Starter Dependencies for the one or more spring-grpc modules you wish to use, e.g. spring-grpc-openai.
 
 [source,gradle]
 ----
 dependencies {
-  implementation platform("org.springframework.grpc:spring-grpc-dependencies:0.4.0-SNAPSHOT")
+  implementation platform("org.springframework.grpc:spring-grpc-bom:0.4.0-SNAPSHOT")
 }
 ----
 


### PR DESCRIPTION
This adds a BOM module that includes the dependencies used by the framework except those that are managed by Spring Boot dependency management. The idea is that Spring Boot applications can use the BOM to get the proper versions for Spring gRPC and non-Spring Boot applications can use `spring-grpc-dependencies`.

Resolves #118