### PR TITLE
Fix docs.yml workflow (add 'package' command)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
         echo BUILD_VERSION=$BUILD_VERSION >> $GITHUB_ENV
     - name: Run Antora
       run: |
-        ./mvnw -pl spring-grpc-docs process-resources antora -P docs
+        ./build-docs.sh
     - name: Publish Docs
       uses: spring-io/spring-doc-actions/rsync-antora-reference@v0.0.11
       with:

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 
+# Be sure the ConfigurationPropertiesAsciidocGenerator is compiled
+./mvnw -pl spring-grpc-docs package
+
+# Generate the config props and antora site
 ./mvnw -pl spring-grpc-docs process-resources antora -P docs


### PR DESCRIPTION
The recent move to do config props generation only at docs generation time left the docs.yml broken as it requires the config props generator class to be compiled prior to running.

This updates the './build-docs.sh' to include the package command as well as update the docs.yml to use the same script.