### PR TITLE
Make maven tree display more friendly

### DIFF
--- a/samples/grpc-client/pom.xml
+++ b/samples/grpc-client/pom.xml
@@ -12,7 +12,7 @@
 	<groupId>org.springframework.grpc</groupId>
 	<artifactId>grpc-client-sample</artifactId>
 	<version>0.6.0-SNAPSHOT</version>
-	<name>Spring gRPC Server Sample</name>
+	<name>Spring gRPC Client Sample</name>
 	<description>Demo project for Spring gRPC</description>
 	<url />
 	<licenses>

--- a/samples/grpc-secure/pom.xml
+++ b/samples/grpc-secure/pom.xml
@@ -12,7 +12,7 @@
 	<groupId>org.springframework.grpc</groupId>
 	<artifactId>grpc-secure-sample</artifactId>
 	<version>0.6.0-SNAPSHOT</version>
-	<name>Spring gRPC Server Sample</name>
+	<name>Spring gRPC Secure Sample</name>
 	<description>Demo project for Spring gRPC</description>
 	<url />
 	<licenses>

--- a/samples/grpc-tomcat-secure/pom.xml
+++ b/samples/grpc-tomcat-secure/pom.xml
@@ -12,7 +12,7 @@
 	<groupId>org.springframework.grpc</groupId>
 	<artifactId>grpc-tomcat-secure-sample</artifactId>
 	<version>0.6.0-SNAPSHOT</version>
-	<name>Spring gRPC Server Sample</name>
+	<name>Spring gRPC Tomcat Secure Sample</name>
 	<description>Demo project for Spring gRPC</description>
 	<url />
 	<licenses>

--- a/samples/grpc-tomcat/pom.xml
+++ b/samples/grpc-tomcat/pom.xml
@@ -12,7 +12,7 @@
 	<groupId>org.springframework.grpc</groupId>
 	<artifactId>grpc-tomcat-sample</artifactId>
 	<version>0.6.0-SNAPSHOT</version>
-	<name>Spring gRPC Server Sample</name>
+	<name>Spring gRPC Tomcat Sample</name>
 	<description>Demo project for Spring gRPC</description>
 	<url />
 	<licenses>

--- a/samples/grpc-webflux/pom.xml
+++ b/samples/grpc-webflux/pom.xml
@@ -12,7 +12,7 @@
 	<groupId>org.springframework.grpc</groupId>
 	<artifactId>grpc-webflux-sample</artifactId>
 	<version>0.6.0-SNAPSHOT</version>
-	<name>Spring gRPC Server Sample</name>
+	<name>Spring gRPC Webflux Sample</name>
 	<description>Demo project for Spring gRPC</description>
 	<url />
 	<licenses>


### PR DESCRIPTION
Before:
<img width="270" alt="image" src="https://github.com/user-attachments/assets/7a06b94f-ad60-4295-bbb5-9a4d8d8dff89" />
Now:
<img width="270" alt="image" src="https://github.com/user-attachments/assets/495eb13a-f459-48ce-98c8-99c44c377831" />

