### PR TITLE
Removes restriction on InProcessServerFactory

### DIFF
--- a/spring-grpc-test/src/main/java/org/springframework/grpc/test/InProcessGrpcServerFactoryAutoConfiguration.java
+++ b/spring-grpc-test/src/main/java/org/springframework/grpc/test/InProcessGrpcServerFactoryAutoConfiguration.java
@@ -20,7 +20,6 @@ import java.util.List;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnNotWebApplication;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
@@ -37,7 +36,6 @@ import io.grpc.inprocess.InProcessServerBuilder;
 @AutoConfiguration(before = { GrpcServerFactoryAutoConfiguration.class, GrpcClientAutoConfiguration.class })
 @ConditionalOnProperty(prefix = "spring.grpc.inprocess", name = "enabled", havingValue = "true")
 @ConditionalOnClass(BindableService.class)
-@ConditionalOnNotWebApplication
 @Import(ClientInterceptorsConfiguration.class)
 public class InProcessGrpcServerFactoryAutoConfiguration {
 


### PR DESCRIPTION
This PR removes the restriction that in process servers only work on non webapp apps. 

We have a number of services that use both webflux and grpc that work well with a local build with this change.

If you have any other feedback, I am all ears and happy to make further changes!