### PR TITLE
Add support for filtering client interceptors in channel factories via user-configured filter bean

### DIFF
--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/ClientInterceptorFilter.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/ClientInterceptorFilter.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.grpc.client;
+
+import io.grpc.ClientInterceptor;
+
+/**
+ * Strategy to determine whether a {@link ClientInterceptor} should be included for a
+ * given {@link GrpcChannelFactory}.
+ *
+ * @author Andrey Litvitski
+ */
+@FunctionalInterface
+public interface ClientInterceptorFilter {
+
+	/**
+	 * Determine whether the given {@link ClientInterceptor} should be included for the
+	 * provided {@link GrpcChannelFactory}.
+	 * @param interceptor the client interceptor under consideration.
+	 * @param channelFactory the channel factory in use.
+	 * @return {@code true} if the interceptor should be included; {@code false}
+	 * otherwise.
+	 */
+	boolean filter(ClientInterceptor interceptor, GrpcChannelFactory channelFactory);
+
+}

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/ClientInterceptorsConfigurer.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/ClientInterceptorsConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2024 the original author or authors.
+ * Copyright 2024-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.grpc.internal.ApplicationContextBeanLookupUtils;
 
@@ -31,12 +32,15 @@ import io.grpc.ManagedChannelBuilder;
  * Configure a {@link ManagedChannelBuilder} with client interceptors.
  *
  * @author Chris Bono
+ * @author Andrey Litvitski
  */
 public class ClientInterceptorsConfigurer implements InitializingBean {
 
 	private final ApplicationContext applicationContext;
 
 	private List<ClientInterceptor> globalInterceptors;
+
+	private ClientInterceptorFilter interceptorFilter;
 
 	public ClientInterceptorsConfigurer(ApplicationContext applicationContext) {
 		this.applicationContext = applicationContext;
@@ -48,13 +52,18 @@ public class ClientInterceptorsConfigurer implements InitializingBean {
 	 * @param interceptors the non-null list of interceptors to be applied to the channel
 	 * @param mergeWithGlobalInterceptors whether the provided interceptors should be
 	 * blended with the global interceptors.
+	 * @param factory the channel factory used to filter global interceptors
 	 */
 	protected void configureInterceptors(ManagedChannelBuilder<?> builder, List<ClientInterceptor> interceptors,
-			boolean mergeWithGlobalInterceptors) {
+			boolean mergeWithGlobalInterceptors, GrpcChannelFactory factory) {
 		// Add global interceptors first
 		List<ClientInterceptor> allInterceptors = new ArrayList<>(this.globalInterceptors);
 		// Add specific interceptors
 		allInterceptors.addAll(interceptors);
+		// Filter all interceptors
+		if (this.interceptorFilter != null) {
+			allInterceptors.removeIf(interceptor -> !this.interceptorFilter.filter(interceptor, factory));
+		}
 		if (mergeWithGlobalInterceptors) {
 			ApplicationContextBeanLookupUtils.sortBeansIncludingOrderAnnotation(this.applicationContext,
 					ClientInterceptor.class, allInterceptors);
@@ -66,11 +75,21 @@ public class ClientInterceptorsConfigurer implements InitializingBean {
 	@Override
 	public void afterPropertiesSet() {
 		this.globalInterceptors = findGlobalInterceptors();
+		this.interceptorFilter = findInterceptorFilter();
 	}
 
 	private List<ClientInterceptor> findGlobalInterceptors() {
 		return ApplicationContextBeanLookupUtils.getBeansWithAnnotation(this.applicationContext,
 				ClientInterceptor.class, GlobalClientInterceptor.class);
+	}
+
+	private ClientInterceptorFilter findInterceptorFilter() {
+		try {
+			return this.applicationContext.getBean(ClientInterceptorFilter.class);
+		}
+		catch (NoSuchBeanDefinitionException ignored) {
+			return null;
+		}
 	}
 
 }

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/DefaultGrpcChannelFactory.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/DefaultGrpcChannelFactory.java
@@ -96,7 +96,7 @@ public class DefaultGrpcChannelFactory<T extends ManagedChannelBuilder<T>>
 		T builder = newChannelBuilder(targetUri, this.credentials.getChannelCredentials(target));
 		// Handle interceptors
 		this.interceptorsConfigurer.configureInterceptors(builder, options.interceptors(),
-				options.mergeWithGlobalInterceptors());
+				options.mergeWithGlobalInterceptors(), this);
 		// Handle customizers
 		this.globalCustomizers.forEach((c) -> c.customize(target, builder));
 		var customizer = options.<T>customizer();

--- a/spring-grpc-core/src/test/java/org/springframework/grpc/client/GrpcChannelFactoryTests.java
+++ b/spring-grpc-core/src/test/java/org/springframework/grpc/client/GrpcChannelFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,7 +110,7 @@ class GrpcChannelFactoryTests {
 			channel = channelFactory.createChannel(channelName);
 			assertThat(channel).isNotNull();
 			verify(configurer).configureInterceptors(any(ManagedChannelBuilder.class),
-					assertArg((interceptors) -> assertThat(interceptors).isEmpty()), eq(false));
+					assertArg((interceptors) -> assertThat(interceptors).isEmpty()), eq(false), eq(channelFactory));
 		}
 
 		@Test
@@ -126,7 +126,8 @@ class GrpcChannelFactoryTests {
 						.withInterceptorsMerge(true));
 			assertThat(channel).isNotNull();
 			verify(configurer).configureInterceptors(any(ManagedChannelBuilder.class),
-					assertArg((interceptors) -> assertThat(interceptors).containsExactly(interceptor)), eq(true));
+					assertArg((interceptors) -> assertThat(interceptors).containsExactly(interceptor)), eq(true),
+					eq(channelFactory));
 		}
 
 	}


### PR DESCRIPTION
In this change, I added the ability for users to add filtering for `ClientInterceptor`.

I added the `ClientInterceptorFilter` interface, which contains the `shouldInclude` method, whose behavior will be configured by the users themselves when creating a bean. During the `afterPropertiesSet` event in `ClientInterceptorsConfigurer`, we find a bean with the new `ClientInterceptorFilter` interface and add all elements to the immutable list `List<ClientInterceptorFilter> interceptorFilters`.

Next, I extended the `configureInterceptors` method by adding a new argument `GrpcChannelFactory factory`. I made the current method an overload of the new one. Now, when this method is called, if `factory != null`, we remove all interceptors that did not pass the filter from `allInterceptors`. The current method was extended because some current tests test this method but do not use `GrpcChannelFactory`, but more on that later. I also added a test that tests this behavior, and everything passes.

However, there are some points that I am unsure about and would like to discuss with you:

1. Should we extend the current method? I implemented this behavior because some current methods do not mock `GrpcChannelFactory` and do not use it. I also did this because I thought that this method could possibly be called with other `GrpcChannelFactory`s. However, we can only have one `GrpcChannelFactory` bean in our system. And if we were to take this bean, we wouldn't have to extend anything. However, I decided to extend it anyway. Please let me know what you think about this.

2. I made a test that performs a simple mechanism: we register the `ClientInterceptorFilter` bean and filter all interceptors that are not `GlobalClientInterceptorsConfig.GLOBAL_INTERCEPTOR_BAR`. This test works correctly; if we didn't use filtering, the test would fail. However, do we want to add another test that checks that the test fails? Let's say we do something like this:
```java
var expected = List.of(GlobalClientInterceptorsConfig.GLOBAL_INTERCEPTOR_FOO, GlobalClientInterceptorsConfig.GLOBAL_INTERCEPTOR_BAR);
verify(builder).intercept(expected);
```
Then we would know for sure that everything works. If we run this test, it will work as intended (it will fail). Obviously, we want to check that it fails, but not that it fails on its own. But there is a nuance, and I don't know how to do it. That is, I tried something like this:
```java
assertThrows(ArgumentsAreDifferent.class, () -> {
    verify(builder).intercept(expected);
});
```
However, an error will be returned:
```java
java: cannot access junit.framework.ComparisonFailure
  class file for junit.framework.ComparisonFailure not found
```

Resolves: #195