### PR TITLE
Allow custom `ObservationGrpcClientInterceptor` via `@ConditionalOnMissingBean`

### DIFF
--- a/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/client/GrpcClientObservationAutoConfiguration.java
+++ b/spring-grpc-spring-boot-autoconfigure/src/main/java/org/springframework/grpc/autoconfigure/client/GrpcClientObservationAutoConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.grpc.autoconfigure.client;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.grpc.client.GlobalClientInterceptor;
@@ -36,6 +37,7 @@ public class GrpcClientObservationAutoConfiguration {
 
 	@Bean
 	@GlobalClientInterceptor
+	@ConditionalOnMissingBean
 	ObservationGrpcClientInterceptor observationGrpcClientInterceptor(ObservationRegistry observationRegistry) {
 		return new ObservationGrpcClientInterceptor(observationRegistry);
 	}


### PR DESCRIPTION
I think that would be more flexible.

Closes: gh-246