### PR TITLE
Don't create observationCoroutineGrpcServerInterceptor bean when micrometer context-propagation isn't present on classpath

### DIFF
--- a/spring-grpc-server-spring-boot-autoconfigure/pom.xml
+++ b/spring-grpc-server-spring-boot-autoconfigure/pom.xml
@@ -143,6 +143,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>context-propagation</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>io.netty</groupId>
 			<artifactId>netty-transport-native-epoll</artifactId>
 			<optional>true</optional>

--- a/spring-grpc-server-spring-boot-autoconfigure/src/main/java/org/springframework/boot/grpc/server/autoconfigure/GrpcServerObservationAutoConfiguration.java
+++ b/spring-grpc-server-spring-boot-autoconfigure/src/main/java/org/springframework/boot/grpc/server/autoconfigure/GrpcServerObservationAutoConfiguration.java
@@ -53,7 +53,7 @@ public final class GrpcServerObservationAutoConfiguration {
 	}
 
 	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnClass(name = "io.grpc.kotlin.AbstractCoroutineStub")
+	@ConditionalOnClass(name = { "io.grpc.kotlin.AbstractCoroutineStub", "io.micrometer.context.ContextRegistry" })
 	static class GrpcServerCoroutineStubConfiguration {
 
 		@Bean

--- a/spring-grpc-server-spring-boot-autoconfigure/src/test/java/org/springframework/boot/grpc/server/autoconfigure/GrpcServerObservationAutoConfigurationTests.java
+++ b/spring-grpc-server-spring-boot-autoconfigure/src/test/java/org/springframework/boot/grpc/server/autoconfigure/GrpcServerObservationAutoConfigurationTests.java
@@ -33,7 +33,9 @@ import org.springframework.grpc.server.GrpcServerFactory;
 
 import io.grpc.BindableService;
 import io.grpc.ServerInterceptor;
+import io.micrometer.context.ContextRegistry;
 import io.micrometer.core.instrument.binder.grpc.ObservationGrpcServerInterceptor;
+import io.micrometer.core.instrument.kotlin.ObservationCoroutineContextServerInterceptor;
 import io.micrometer.observation.ObservationRegistry;
 
 /**
@@ -129,6 +131,14 @@ class GrpcServerObservationAutoConfigurationTests {
 						.toList();
 					return annotated.size() == 2 && interceptors.get(0) instanceof ObservationGrpcServerInterceptor;
 				}, "Two global interceptors expected")));
+	}
+
+	@Test
+	void whenMicrometerContextPropagationIsNotOnClasspathCoroutineInterceptorIsNotCreated() {
+		this.validContextRunner()
+			.withClassLoader(new FilteredClassLoader(ContextRegistry.class))
+			.run((context) -> assertThat(context).hasSingleBean(ObservationGrpcServerInterceptor.class)
+				.doesNotHaveBean(ObservationCoroutineContextServerInterceptor.class));
 	}
 
 }


### PR DESCRIPTION
Answering a bit late on the question in #282 

As it was mentioned in #283 the issue is caused by `context-propagation` missing on a classpath. The root-cause is a bit deeper. If observation is configured spring-grpc will create a `ObservationCoroutineContextServerInterceptor` bean specifically for kotlin coroutine-based servers. Although this class doesn't require context-propagation directly, its dependency `KotlinObservationContextElement` does. That's why the kotlin-sample server starts, but then it fails to process a request silently. Enabling the logs gives the root-cause:
```
2025-11-10T16:29:19.911+01:00 ERROR 27640 --- [grpc-server-kotlin] [ault-executor-0] eptionHandlerInterceptor$FallbackHandler : Unknown exception

java.lang.NoClassDefFoundError: io/micrometer/context/ContextRegistry
	at io.micrometer.core.instrument.kotlin.AsContextElementKt.asContextElement(AsContextElement.kt:31) ~[micrometer-core-1.16.0-RC1.jar:1.16.0-RC1]
	at io.micrometer.core.instrument.kotlin.ObservationCoroutineContextServerInterceptor.coroutineContext(ObservationCoroutineContextServerInterceptor.kt:45) ~[micrometer-core-1.16.0-RC1.jar:1.16.0-RC1]
	at io.grpc.kotlin.CoroutineContextServerInterceptor.interceptCall(CoroutineContextServerInterceptor.kt:61) ~[grpc-kotlin-stub-1.5.0.jar:na]
	at io.grpc.ServerInterceptors$InterceptCallHandler.startCall(ServerInterceptors.java:269) ~[grpc-api-1.76.0.jar:1.76.0]
	at io.micrometer.core.instrument.binder.grpc.ObservationGrpcServerInterceptor.interceptCall(ObservationGrpcServerInterceptor.java:124) ~[micrometer-core-1.16.0-RC1.jar:1.16.0-RC1]
	at io.grpc.ServerInterceptors$InterceptCallHandler.startCall(ServerInterceptors.java:269) ~[grpc-api-1.76.0.jar:1.76.0]
	at org.springframework.grpc.server.exception.GrpcExceptionHandlerInterceptor.interceptCall(GrpcExceptionHandlerInterceptor.java:74) ~[classes/:na]
	at io.grpc.ServerInterceptors$InterceptCallHandler.startCall(ServerInterceptors.java:269) ~[grpc-api-1.76.0.jar:1.76.0]
	at io.grpc.internal.ServerImpl$ServerTransportListenerImpl.startWrappedCall(ServerImpl.java:701) ~[grpc-core-1.76.0.jar:1.76.0]
	at io.grpc.internal.ServerImpl$ServerTransportListenerImpl.access$2200(ServerImpl.java:408) ~[grpc-core-1.76.0.jar:1.76.0]
	at io.grpc.internal.ServerImpl$ServerTransportListenerImpl$1HandleServerCall.runInternal(ServerImpl.java:613) ~[grpc-core-1.76.0.jar:1.76.0]
	at io.grpc.internal.ServerImpl$ServerTransportListenerImpl$1HandleServerCall.runInContext(ServerImpl.java:603) ~[grpc-core-1.76.0.jar:1.76.0]
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37) ~[grpc-core-1.76.0.jar:1.76.0]
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133) ~[grpc-core-1.76.0.jar:1.76.0]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[na:na]
	at java.base/java.lang.Thread.run(Thread.java:1583) ~[na:na]
Caused by: java.lang.ClassNotFoundException: io.micrometer.context.ContextRegistry
	... 17 common frames omitted
```

In RC1 `spring-boot-starter-actuator` provided context-propagation via `spring-boot-micrometer-tracing`, but it's not the case anymore, see https://github.com/spring-projects/spring-boot/issues/47785.

Given all that, I propose a safe solution: don't create a `ObservationCoroutineContextServerInterceptor` bean if context-propagation isn't available.