### PR TITLE
Require closing comment and blank line in file headers

### DIFF
--- a/samples/grpc-server/src/test/java/org/springframework/grpc/sample/GrpcServerSideTests.java
+++ b/samples/grpc-server/src/test/java/org/springframework/grpc/sample/GrpcServerSideTests.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.sample;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/AbstractGrpcClientRegistrar.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/AbstractGrpcClientRegistrar.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.client;
 
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/AbstractStubFactory.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/AbstractStubFactory.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.client;
 
 import java.util.function.Supplier;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/AnnotationGrpcClientRegistrar.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/AnnotationGrpcClientRegistrar.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.client;
 
 import java.util.HashSet;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/BlockingStubFactory.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/BlockingStubFactory.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.client;
 
 import io.grpc.stub.AbstractBlockingStub;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/BlockingV2StubFactory.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/BlockingV2StubFactory.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.client;
 
 import io.grpc.stub.AbstractBlockingStub;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/ChannelBuilderOptions.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/ChannelBuilderOptions.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.client;
 
 import java.time.Duration;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/ChannelCredentialsProvider.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/ChannelCredentialsProvider.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * */
+ */
 
 package org.springframework.grpc.client;
 

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/ClientInterceptorFilter.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/ClientInterceptorFilter.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.client;
 
 import io.grpc.ClientInterceptor;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/ClientInterceptorsConfigurer.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/ClientInterceptorsConfigurer.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * */
+ */
 
 package org.springframework.grpc.client;
 

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/CoroutineStubFactory.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/CoroutineStubFactory.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * */
+ */
 
 package org.springframework.grpc.client;
 

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/FutureStubFactory.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/FutureStubFactory.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.client;
 
 import io.grpc.stub.AbstractBlockingStub;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/GlobalClientInterceptor.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/GlobalClientInterceptor.java
@@ -12,8 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Partial copy from net.devh:grpc-spring-boot-starter.
  */
 
 package org.springframework.grpc.client;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/GrpcClientFactory.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/GrpcClientFactory.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.client;
 
 import java.io.IOException;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/ImportGrpcClients.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/ImportGrpcClients.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.client;
 
 import java.lang.annotation.Documented;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/InProcessGrpcChannelFactory.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/InProcessGrpcChannelFactory.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.client;
 
 import java.util.List;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/ReactorStubFactory.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/ReactorStubFactory.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.client;
 
 import io.grpc.stub.AbstractStub;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/SimpleStubFactory.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/SimpleStubFactory.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.client;
 
 import java.lang.reflect.Method;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/StubFactory.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/StubFactory.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.client;
 
 import java.util.function.Supplier;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/UnspecifiedStubFactory.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/UnspecifiedStubFactory.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.client;
 
 import io.grpc.stub.AbstractStub;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/aot/ClientBeanRegistrationsAotProcessor.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/aot/ClientBeanRegistrationsAotProcessor.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.client.aot;
 
 import java.lang.reflect.Modifier;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/interceptor/DefaultDeadlineSetupClientInterceptor.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/interceptor/DefaultDeadlineSetupClientInterceptor.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-  */
+ */
 
 package org.springframework.grpc.client.interceptor;
 

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/interceptor/security/BasicAuthenticationInterceptor.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/interceptor/security/BasicAuthenticationInterceptor.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.client.interceptor.security;
 
 import java.util.Base64;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/interceptor/security/BearerTokenAuthenticationInterceptor.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/interceptor/security/BearerTokenAuthenticationInterceptor.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.client.interceptor.security;
 
 import java.util.function.Supplier;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/internal/ApplicationContextBeanLookupUtils.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/internal/ApplicationContextBeanLookupUtils.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.internal;
 
 import java.lang.annotation.Annotation;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/internal/ClasspathScanner.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/internal/ClasspathScanner.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.internal;
 
 import java.io.FileNotFoundException;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/GrpcServerFactory.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/GrpcServerFactory.java
@@ -12,8 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Partial copy from net.devh:grpc-spring-boot-starter.
  */
 
 package org.springframework.grpc.server;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/InProcessGrpcServerFactory.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/InProcessGrpcServerFactory.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.server;
 
 import java.util.List;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/ServerServiceDefinitionFilter.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/ServerServiceDefinitionFilter.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.server;
 
 import io.grpc.ServerServiceDefinition;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/exception/CompositeGrpcExceptionHandler.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/exception/CompositeGrpcExceptionHandler.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.server.exception;
 
 import io.grpc.StatusException;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/exception/GrpcExceptionHandledServerCall.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/exception/GrpcExceptionHandledServerCall.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.server.exception;
 
 import io.grpc.ForwardingServerCall;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/exception/GrpcExceptionHandler.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/exception/GrpcExceptionHandler.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.server.exception;
 
 import io.grpc.StatusException;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/exception/GrpcExceptionHandlerInterceptor.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/exception/GrpcExceptionHandlerInterceptor.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.server.exception;
 
 import org.apache.commons.logging.Log;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/exception/ReactiveStubBeanDefinitionRegistrar.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/exception/ReactiveStubBeanDefinitionRegistrar.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.server.exception;
 
 import java.lang.reflect.Method;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/lifecycle/GrpcServerLifecycle.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/lifecycle/GrpcServerLifecycle.java
@@ -12,8 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Partial copy from net.devh:grpc-spring-boot-starter.
  */
 
 package org.springframework.grpc.server.lifecycle;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/lifecycle/GrpcServerLifecycleEvent.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/lifecycle/GrpcServerLifecycleEvent.java
@@ -12,8 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Partial copy from net.devh:grpc-spring-boot-starter.
  */
 
 package org.springframework.grpc.server.lifecycle;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/lifecycle/GrpcServerShutdownEvent.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/lifecycle/GrpcServerShutdownEvent.java
@@ -12,8 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Partial copy from net.devh:grpc-spring-boot-starter.
  */
 
 package org.springframework.grpc.server.lifecycle;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/lifecycle/GrpcServerStartedEvent.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/lifecycle/GrpcServerStartedEvent.java
@@ -12,8 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Partial copy from net.devh:grpc-spring-boot-starter.
  */
 
 package org.springframework.grpc.server.lifecycle;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/lifecycle/GrpcServerTerminatedEvent.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/lifecycle/GrpcServerTerminatedEvent.java
@@ -12,8 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Partial copy from net.devh:grpc-spring-boot-starter.
  */
 
 package org.springframework.grpc.server.lifecycle;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/AuthenticationProcessInterceptor.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/AuthenticationProcessInterceptor.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.server.security;
 
 import org.springframework.core.Ordered;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/BearerTokenAuthenticationExtractor.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/BearerTokenAuthenticationExtractor.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.server.security;
 
 import java.util.Locale;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/CallContext.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/CallContext.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.server.security;
 
 import io.grpc.Attributes;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/CallMatcher.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/CallMatcher.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.server.security;
 
 interface CallMatcher {

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/GrpcAuthenticationExtractor.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/GrpcAuthenticationExtractor.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.server.security;
 
 import org.springframework.security.core.Authentication;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/GrpcSecurity.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/GrpcSecurity.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.server.security;
 
 import java.util.ArrayList;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/HttpBasicAuthenticationExtractor.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/HttpBasicAuthenticationExtractor.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.server.security;
 
 import java.nio.charset.StandardCharsets;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/HttpBasicConfigurer.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/HttpBasicConfigurer.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.server.security;
 
 import org.springframework.context.ApplicationContext;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/OAuth2ResourceServerConfigurer.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/OAuth2ResourceServerConfigurer.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.server.security;
 
 import java.util.function.Supplier;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/PreAuthConfigurer.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/PreAuthConfigurer.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.server.security;
 
 import org.springframework.context.ApplicationContext;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/RequestMapperConfigurer.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/RequestMapperConfigurer.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.server.security;
 
 import java.util.ArrayList;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/SecurityContextServerInterceptor.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/SecurityContextServerInterceptor.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.server.security;
 
 import org.springframework.core.Ordered;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/SecurityGrpcExceptionHandler.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/SecurityGrpcExceptionHandler.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.server.security;
 
 import org.apache.commons.logging.Log;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/SslContextPreAuthenticationExtractor.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/SslContextPreAuthenticationExtractor.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.server.security;
 
 import java.security.cert.Certificate;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/service/DefaultGrpcServiceConfigurer.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/service/DefaultGrpcServiceConfigurer.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.server.service;
 
 import java.util.ArrayList;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/service/GrpcService.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/service/GrpcService.java
@@ -12,8 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Copy from net.devh:grpc-spring-boot-starter.
  */
 
 package org.springframework.grpc.server.service;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/service/GrpcServiceInfo.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/service/GrpcServiceInfo.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.server.service;
 
 import java.util.List;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/service/GrpcServiceSpec.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/service/GrpcServiceSpec.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.server.service;
 
 import org.springframework.lang.Nullable;

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/service/ServerInterceptorFilter.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/service/ServerInterceptorFilter.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.server.service;
 
 import io.grpc.ServerInterceptor;

--- a/spring-grpc-core/src/test/java/org/springframework/grpc/client/ChannelBuilderOptionsTests.java
+++ b/spring-grpc-core/src/test/java/org/springframework/grpc/client/ChannelBuilderOptionsTests.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.client;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spring-grpc-core/src/test/java/org/springframework/grpc/client/CompositeGrpcChannelFactoryTests.java
+++ b/spring-grpc-core/src/test/java/org/springframework/grpc/client/CompositeGrpcChannelFactoryTests.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.client;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spring-grpc-core/src/test/java/org/springframework/grpc/client/DefaultGrpcChannelFactoryShutdownTests.java
+++ b/spring-grpc-core/src/test/java/org/springframework/grpc/client/DefaultGrpcChannelFactoryShutdownTests.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.client;
 
 import static org.mockito.ArgumentMatchers.anyLong;

--- a/spring-grpc-core/src/test/java/org/springframework/grpc/client/GrpcChannelFactoryTests.java
+++ b/spring-grpc-core/src/test/java/org/springframework/grpc/client/GrpcChannelFactoryTests.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.client;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spring-grpc-core/src/test/java/org/springframework/grpc/client/GrpcClientFactoryTests.java
+++ b/spring-grpc-core/src/test/java/org/springframework/grpc/client/GrpcClientFactoryTests.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.client;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spring-grpc-core/src/test/java/org/springframework/grpc/internal/ClasspathScannerTests.java
+++ b/spring-grpc-core/src/test/java/org/springframework/grpc/internal/ClasspathScannerTests.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spring-grpc-core/src/test/java/org/springframework/grpc/internal/GrpcUtilsTests.java
+++ b/spring-grpc-core/src/test/java/org/springframework/grpc/internal/GrpcUtilsTests.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spring-grpc-core/src/test/java/org/springframework/grpc/server/exception/GrpcExceptionHandlerInterceptorTests.java
+++ b/spring-grpc-core/src/test/java/org/springframework/grpc/server/exception/GrpcExceptionHandlerInterceptorTests.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.server.exception;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spring-grpc-core/src/test/java/org/springframework/grpc/server/exception/ReactiveStubBeanDefinitionRegistrarTests.java
+++ b/spring-grpc-core/src/test/java/org/springframework/grpc/server/exception/ReactiveStubBeanDefinitionRegistrarTests.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.server.exception;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spring-grpc-core/src/test/java/org/springframework/grpc/server/service/GrpcServiceInfoTests.java
+++ b/spring-grpc-core/src/test/java/org/springframework/grpc/server/service/GrpcServiceInfoTests.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.grpc.server.service;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/checkstyle/checkstyle-header.txt
+++ b/src/checkstyle/checkstyle-header.txt
@@ -12,3 +12,6 @@
 ^\Q * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\E$
 ^\Q * See the License for the specific language governing permissions and\E$
 ^\Q * limitations under the License.\E$
+^\Q */\E$
+^$
+^.*$


### PR DESCRIPTION
I noticed that our `checkstyle-header` is different from other `checkstyle-header` files in other Spring projects. We could bring the copyright header to the same format. In principle, this was what it was all about, but now it's not exactly happening.

I added in `checkstyle-header.txt` new rules that make sure that the header is closed, that there is an empty line, and that other code can follow. There are similar rules in other spring projects, such as spring security or spring pulsar.