### PR TITLE
Support Java 25

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -15,11 +15,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 17 (0.x)
+        if: github.base_ref == '0.x'
         uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
+          cache: maven
+      - name: Set up JDK 25 (main)
+        if: github.base_ref == 'main'
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'liberica'
           cache: maven
       - name: Build and test
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,11 +14,19 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 17
+    - name: Set up JDK 17 (0.x)
+      if: startsWith(github.ref, 'refs/heads/0.x/')
       uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'temurin'
+        cache: maven
+    - name: Set up JDK 25 (main)
+      if: startsWith(github.ref, 'refs/heads/main/')
+      uses: actions/setup-java@v4
+      with:
+        java-version: '25'
+        distribution: 'liberica'
         cache: maven
     - name: Deploy with Maven
       env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,11 +19,19 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 5
-    - name: Set up JDK 17
+    - name: Set up JDK 17 (0.x)
+      if: startsWith(github.ref, 'refs/heads/0.x/')
       uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'temurin'
+        cache: maven
+    - name: Set up JDK 25 (main)
+      if: startsWith(github.ref, 'refs/heads/main/')
+      uses: actions/setup-java@v4
+      with:
+        java-version: '25'
+        distribution: 'liberica'
         cache: maven
     - name: Set up refname build
       if: github.event.inputs.build-refname

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,14 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
+--add-opens=java.base/java.util=ALL-UNNAMED
+--add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+--add-opens=java.base/java.text=ALL-UNNAMED
+--add-opens=java.desktop/java.awt.font=ALL-UNNAMED

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,3 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=25-librca

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
 		<junit.version>5.13.4</junit.version>
 		<assertj.version>3.27.4</assertj.version>
 		<awaitility.version>4.3.0</awaitility.version>
-		<mockito.version>5.19.0</mockito.version>
+		<mockito.version>5.20.0</mockito.version>
 		<!-- documentation dependencies -->
 		<io.spring.maven.antora-version>0.0.4</io.spring.maven.antora-version>
 		<!-- FIXME build failure with version 2.3.9: -->
@@ -95,7 +95,7 @@
 		<spring-asciidoctor-backends.version>0.0.6</spring-asciidoctor-backends.version>
 
 		<!-- plugin versions -->
-		<maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+		<maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
 		<maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
 		<maven-failsafe-plugin.version>3.1.2</maven-failsafe-plugin.version>
 		<maven-flatten-plugin.version>1.6.0</maven-flatten-plugin.version>
@@ -202,7 +202,8 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>${maven-surefire-plugin.version}</version>
 				<configuration>
-					<argLine>${surefireArgLine}</argLine>
+					<!-- required for Java 25 and Mockito inline mocks -->
+					<argLine>-Dnet.bytebuddy.experimental=true</argLine>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
This commit adds support for Java 25. Note that the java.version remains at 17 in order to force the target and source compatibility to be 17. However, if the running JVM is 25 it will be used to compile and run tests.

The Github workflows are also updated to run with Java 25.

**TODO**
- [ ] Make samples run w/ both 17 and 25

See #290