### PR TITLE
Remove unnecessary dependency exclusions

### DIFF
--- a/spring-grpc-core/pom.xml
+++ b/spring-grpc-core/pom.xml
@@ -74,20 +74,6 @@
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-protobuf</artifactId>
-			<exclusions>
-				<exclusion>
-					<groupId>com.google.protobuf</groupId>
-					<artifactId>protobuf-java</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.google.api.grpc</groupId>
-					<artifactId>proto-google-common-protos</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>com.google.protobuf</groupId>
-			<artifactId>protobuf-java</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>io.grpc</groupId>

--- a/spring-grpc-dependencies/pom.xml
+++ b/spring-grpc-dependencies/pom.xml
@@ -115,21 +115,6 @@
 			</dependency>
 			<dependency>
 				<groupId>io.grpc</groupId>
-				<artifactId>grpc-services</artifactId>
-				<version>${grpc.version}</version>
-				<exclusions>
-					<exclusion>
-						<groupId>com.google.protobuf</groupId>
-						<artifactId>protobuf-java</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>com.google.api.grpc</groupId>
-						<artifactId>proto-google-common-protos</artifactId>
-					</exclusion>
-				</exclusions>
-			</dependency>
-			<dependency>
-				<groupId>io.grpc</groupId>
 				<artifactId>grpc-kotlin-stub</artifactId>
 				<version>${grpc-kotlin.version}</version>
 			</dependency>


### PR DESCRIPTION
This removes unnecessary exclusions of Google `protobuf-java` and `proto-google-common-protos` dependencies from `spring-grpc-core` and `spring-grpc-dependencies` modules as the desired versions are properly overridden without the exclusions.

### Details

In digging into whether we should bump the Google protobuf and common protos libs, I revisited the exclusions we had in several POMs and as it turns out we do not need them in there. The dependencyManagement does its job and overrides the transitive Google protobuf-java and proto-common-google-protos to the expected versions.

We are expecting the following:

- io.grpc:grpc-protobuf:1.77.0
- com.google.protobuf:protobuf-java:4.32.1
- com.google.api.grpc:proto-google-common-protos:2.61.2

And after running these changes locally and issuing the following commands you can see the versions are all as expected:

```
DEP="io.grpc:grpc-protobuf"
./mvnw dependency:tree -Dverbose -Dincludes="$DEP" | grep -E "$DEP"
```
Produces all `1.77.0`s

```
DEP="com.google.protobuf:protobuf-java"
./mvnw dependency:tree -Dverbose -Dincludes="$DEP" | grep -E "$DEP"
```
Produces all `4.32.1`s

```
DEP="com.google.api.grpc:proto-google-common-protos"
./mvnw dependency:tree -Dverbose -Dincludes="$DEP" | grep -E "$DEP"
```
Produces all `2.61.2`s