### PR TITLE
Fix: Missing secure field in ChannelConfig.copy() method

### DIFF
--- a/spring-grpc-client-spring-boot-autoconfigure/src/main/java/org/springframework/boot/grpc/client/autoconfigure/GrpcClientProperties.java
+++ b/spring-grpc-client-spring-boot-autoconfigure/src/main/java/org/springframework/boot/grpc/client/autoconfigure/GrpcClientProperties.java
@@ -361,6 +361,7 @@ public class GrpcClientProperties implements EnvironmentAware, VirtualTargets {
 			copy.maxInboundMetadataSize = this.maxInboundMetadataSize;
 			copy.userAgent = this.userAgent;
 			copy.defaultDeadline = this.defaultDeadline;
+			copy.secure = this.secure;
 			copy.health.copyValuesFrom(this.getHealth());
 			copy.ssl.copyValuesFrom(this.getSsl());
 			copy.serviceConfig.putAll(this.serviceConfig);

--- a/spring-grpc-client-spring-boot-autoconfigure/src/test/java/org/springframework/boot/grpc/client/autoconfigure/GrpcClientPropertiesTests.java
+++ b/spring-grpc-client-spring-boot-autoconfigure/src/test/java/org/springframework/boot/grpc/client/autoconfigure/GrpcClientPropertiesTests.java
@@ -234,6 +234,7 @@ class GrpcClientPropertiesTests {
 			defaultChannel.setMaxInboundMetadataSize(DataSize.ofMegabytes(200));
 			defaultChannel.setUserAgent("me");
 			defaultChannel.setDefaultDeadline(Duration.ofMinutes(1));
+			defaultChannel.setSecure(false);
 			defaultChannel.getSsl().setEnabled(true);
 			defaultChannel.getSsl().setBundle("custom-bundle");
 			var properties = newProperties(defaultChannel, Collections.emptyMap());


### PR DESCRIPTION
The secure field is not being copied in the ChannelConfig.copy() method, which can lead to incorrect channel configuration when a channel config is copied after modifying the secure flag from its default value. For example while setting the `spring.grpc.client.default-channel.secure` to `false` and then call the `getChannel()` with an unknown name the secure field would still be set to `true` in the returned instance.


## Changes

* Added the field assignment to the copy method
* Modified the unit test to verify it

## Note
I also thought about how to enforce future extensions of the ChannelConfig to modify the copy method but I could think of nothing but using the `java.land.reflect` api which I currently think is not a preferred option in this project. But I will accept any other recomendations.