### PR TITLE
Add @GrpcClient annotation for field injection

### DIFF
--- a/spring-grpc-client-spring-boot-autoconfigure/src/main/java/org/springframework/boot/grpc/client/autoconfigure/GrpcClientAutoConfiguration.java
+++ b/spring-grpc-client-spring-boot-autoconfigure/src/main/java/org/springframework/boot/grpc/client/autoconfigure/GrpcClientAutoConfiguration.java
@@ -32,6 +32,7 @@ import org.springframework.grpc.client.ChannelCredentialsProvider;
 import org.springframework.grpc.client.ClientInterceptorsConfigurer;
 import org.springframework.grpc.client.CoroutineStubFactory;
 import org.springframework.grpc.client.GrpcChannelBuilderCustomizer;
+import org.springframework.grpc.client.GrpcClientBeanPostProcessor;
 import org.springframework.grpc.client.GrpcClientFactory;
 
 import io.grpc.CompressorRegistry;
@@ -50,6 +51,12 @@ public final class GrpcClientAutoConfiguration {
 	@ConditionalOnMissingBean
 	ClientInterceptorsConfigurer clientInterceptorsConfigurer(ApplicationContext applicationContext) {
 		return new ClientInterceptorsConfigurer(applicationContext);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	static GrpcClientBeanPostProcessor grpcClientBeanPostProcessor() {
+		return new GrpcClientBeanPostProcessor();
 	}
 
 	@Bean

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/GrpcClient.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/GrpcClient.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2024-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.grpc.client;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.grpc.Channel;
+import io.grpc.ClientInterceptor;
+import io.grpc.stub.AbstractStub;
+
+/**
+ * Annotation for fields of type {@link Channel} or subclasses of {@link AbstractStub}
+ * (gRPC client stubs). Also works for annotated methods that only take a single parameter
+ * of these types. Annotated fields/methods will be automatically populated/invoked by
+ * Spring.
+ *
+ * @author Oleksandr Shevchenko
+ * @see GrpcClientBeanPostProcessor
+ */
+@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+public @interface GrpcClient {
+
+	/**
+	 * The name of the gRPC channel/client.
+	 * @return the name of the gRPC channel/client
+	 */
+	String value() default "default";
+
+	/**
+	 * The {@link ClientInterceptor} bean types to be applied to this client.
+	 * @return the interceptor bean types to be applied to this client
+	 */
+	Class<? extends ClientInterceptor>[] interceptors() default {};
+
+	/**
+	 * The {@link ClientInterceptor} bean names to be applied to this client.
+	 * @return the interceptor bean names to be applied to this client
+	 */
+	String[] interceptorNames() default {};
+
+	/**
+	 * Whether the client-specific interceptors should be blended with the global
+	 * interceptors.
+	 * @return whether the client-specific interceptors should be blended with the global
+	 * interceptors
+	 */
+	boolean blendWithGlobalInterceptors() default false;
+
+}

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/GrpcClientBeanPostProcessor.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/GrpcClientBeanPostProcessor.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright 2024-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.grpc.client;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.beans.BeanInstantiationException;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.util.Assert;
+import org.springframework.util.ReflectionUtils;
+
+import io.grpc.Channel;
+import io.grpc.ClientInterceptor;
+import io.grpc.stub.AbstractStub;
+
+/**
+ * A {@link BeanPostProcessor} that processes {@link GrpcClient @GrpcClient} annotations
+ * on fields and setter methods to inject gRPC clients (stubs or channels).
+ * <p>
+ * This processor will:
+ * <ul>
+ * <li>Scan beans for fields/methods annotated with {@link GrpcClient @GrpcClient}</li>
+ * <li>Create the appropriate gRPC client stub or channel</li>
+ * <li>Apply any specified interceptors</li>
+ * <li>Inject the created client into the field/method</li>
+ * </ul>
+ *
+ * @author Oleksandr Shevchenko
+ * @see GrpcClient
+ * @see GrpcClientFactory
+ */
+public class GrpcClientBeanPostProcessor implements BeanPostProcessor, ApplicationContextAware {
+
+	private @Nullable ApplicationContext applicationContext;
+
+	private final Map<Class<?>, List<InjectionTarget>> injectionTargetsCache = new ConcurrentHashMap<>();
+
+	@Override
+	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		this.applicationContext = applicationContext;
+	}
+
+	@Override
+	public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+		Class<?> beanClass = bean.getClass();
+		List<InjectionTarget> targets = findInjectionTargets(beanClass);
+
+		for (InjectionTarget target : targets) {
+			try {
+				Object client = createClient(target);
+				target.inject(bean, client);
+			}
+			catch (Exception ex) {
+				throw new BeanCreationException(beanName, "Failed to inject gRPC client for " + target.getMember(), ex);
+			}
+		}
+
+		return bean;
+	}
+
+	private List<InjectionTarget> findInjectionTargets(Class<?> beanClass) {
+		return this.injectionTargetsCache.computeIfAbsent(beanClass, this::doFindInjectionTargets);
+	}
+
+	private List<InjectionTarget> doFindInjectionTargets(Class<?> beanClass) {
+		List<InjectionTarget> targets = new ArrayList<>();
+
+		ReflectionUtils.doWithFields(beanClass, field -> {
+			GrpcClient annotation = AnnotationUtils.findAnnotation(field, GrpcClient.class);
+			if (annotation != null) {
+				if (Modifier.isStatic(field.getModifiers())) {
+					throw new IllegalStateException(
+							"@GrpcClient annotation is not supported on static fields: " + field);
+				}
+				targets.add(new FieldInjectionTarget(field, annotation));
+			}
+		});
+
+		ReflectionUtils.doWithMethods(beanClass, method -> {
+			GrpcClient annotation = AnnotationUtils.findAnnotation(method, GrpcClient.class);
+			if (annotation != null) {
+				if (Modifier.isStatic(method.getModifiers())) {
+					throw new IllegalStateException(
+							"@GrpcClient annotation is not supported on static methods: " + method);
+				}
+				if (method.getParameterCount() != 1) {
+					throw new IllegalStateException(
+							"@GrpcClient annotation on methods requires exactly one parameter: " + method);
+				}
+				targets.add(new MethodInjectionTarget(method, annotation));
+			}
+		});
+
+		return targets;
+	}
+
+	private Object createClient(InjectionTarget target) {
+		Class<?> clientType = target.getClientType();
+		GrpcClient annotation = target.getAnnotation();
+
+		List<ClientInterceptor> interceptors = resolveInterceptors(annotation);
+		ChannelBuilderOptions options = ChannelBuilderOptions.defaults()
+			.withInterceptors(interceptors)
+			.withInterceptorsMerge(annotation.blendWithGlobalInterceptors());
+
+		if (Channel.class.isAssignableFrom(clientType)) {
+			return getChannelFactory().createChannel(annotation.value(), options);
+		}
+
+		if (AbstractStub.class.isAssignableFrom(clientType)) {
+			return getClientFactory().getClient(annotation.value(), clientType, UnspecifiedStubFactory.class, options);
+		}
+
+		throw new BeanInstantiationException(clientType,
+				"Unsupported gRPC client type. Expected Channel or AbstractStub subclass.");
+	}
+
+	private List<ClientInterceptor> resolveInterceptors(GrpcClient annotation) {
+		List<ClientInterceptor> interceptors = new ArrayList<>();
+		ApplicationContext context = requireApplicationContext();
+
+		for (Class<? extends ClientInterceptor> interceptorClass : annotation.interceptors()) {
+			ClientInterceptor interceptor = resolveInterceptorByType(context, interceptorClass);
+			interceptors.add(interceptor);
+		}
+
+		for (String interceptorName : annotation.interceptorNames()) {
+			ClientInterceptor interceptor = context.getBean(interceptorName, ClientInterceptor.class);
+			interceptors.add(interceptor);
+		}
+
+		return interceptors;
+	}
+
+	private ClientInterceptor resolveInterceptorByType(ApplicationContext context,
+			Class<? extends ClientInterceptor> interceptorClass) {
+		try {
+			return context.getBean(interceptorClass);
+		}
+		catch (BeansException ex) {
+			try {
+				return interceptorClass.getDeclaredConstructor().newInstance();
+			}
+			catch (Exception instantiationEx) {
+				throw new BeanCreationException(
+						"Failed to instantiate ClientInterceptor: " + interceptorClass.getName()
+								+ ". Make sure it's available as a bean or has a no-args constructor.",
+						instantiationEx);
+			}
+		}
+	}
+
+	private ApplicationContext requireApplicationContext() {
+		Assert.state(this.applicationContext != null, "ApplicationContext has not been set");
+		return this.applicationContext;
+	}
+
+	private GrpcClientFactory getClientFactory() {
+		return requireApplicationContext().getBean(GrpcClientFactory.class);
+	}
+
+	private GrpcChannelFactory getChannelFactory() {
+		return requireApplicationContext().getBean(GrpcChannelFactory.class);
+	}
+
+	/**
+	 * Represents an injection target (field or method) annotated with {@link GrpcClient}.
+	 */
+	private interface InjectionTarget {
+
+		Member getMember();
+
+		Class<?> getClientType();
+
+		GrpcClient getAnnotation();
+
+		void inject(Object bean, Object client);
+
+	}
+
+	/**
+	 * Injection target for fields annotated with {@link GrpcClient}.
+	 */
+	private static class FieldInjectionTarget implements InjectionTarget {
+
+		private final Field field;
+
+		private final GrpcClient annotation;
+
+		FieldInjectionTarget(Field field, GrpcClient annotation) {
+			this.field = field;
+			this.annotation = annotation;
+		}
+
+		@Override
+		public Member getMember() {
+			return this.field;
+		}
+
+		@Override
+		public Class<?> getClientType() {
+			return this.field.getType();
+		}
+
+		@Override
+		public GrpcClient getAnnotation() {
+			return this.annotation;
+		}
+
+		@Override
+		public void inject(Object bean, Object client) {
+			ReflectionUtils.makeAccessible(this.field);
+			ReflectionUtils.setField(this.field, bean, client);
+		}
+
+	}
+
+	/**
+	 * Injection target for setter methods annotated with {@link GrpcClient}.
+	 */
+	private static class MethodInjectionTarget implements InjectionTarget {
+
+		private final Method method;
+
+		private final GrpcClient annotation;
+
+		MethodInjectionTarget(Method method, GrpcClient annotation) {
+			this.method = method;
+			this.annotation = annotation;
+		}
+
+		@Override
+		public Member getMember() {
+			return this.method;
+		}
+
+		@Override
+		public Class<?> getClientType() {
+			return this.method.getParameterTypes()[0];
+		}
+
+		@Override
+		public GrpcClient getAnnotation() {
+			return this.annotation;
+		}
+
+		@Override
+		public void inject(Object bean, Object client) {
+			ReflectionUtils.makeAccessible(this.method);
+			ReflectionUtils.invokeMethod(this.method, bean, client);
+		}
+
+	}
+
+}

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/GrpcClientFactory.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/GrpcClientFactory.java
@@ -83,9 +83,13 @@ public class GrpcClientFactory implements ApplicationContextAware {
 	}
 
 	public <T> T getClient(String target, Class<T> type, Class<?> factory) {
+		return getClient(target, type, factory, ChannelBuilderOptions.defaults());
+	}
+
+	public <T> T getClient(String target, Class<T> type, Class<?> factory, ChannelBuilderOptions options) {
 		@SuppressWarnings("unchecked")
 		StubFactory<T> stubs = (StubFactory<T>) findFactory(factory, type);
-		T client = (T) stubs.create(() -> channels().createChannel(target, ChannelBuilderOptions.defaults()), type);
+		T client = (T) stubs.create(() -> channels().createChannel(target, options), type);
 		return client;
 	}
 

--- a/spring-grpc-core/src/test/java/org/springframework/grpc/client/GrpcClientTests.java
+++ b/spring-grpc-core/src/test/java/org/springframework/grpc/client/GrpcClientTests.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2024-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.grpc.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.Test;
+
+import io.grpc.Channel;
+import io.grpc.ClientInterceptor;
+
+/**
+ * Tests for {@link GrpcClient}.
+ *
+ */
+class GrpcClientTests {
+
+	@Test
+	void defaultValues() throws Exception {
+		GrpcClient annotation = getAnnotation("defaultChannel");
+
+		assertThat(annotation.value()).isEqualTo("default");
+		assertThat(annotation.interceptors()).isEmpty();
+		assertThat(annotation.interceptorNames()).isEmpty();
+		assertThat(annotation.blendWithGlobalInterceptors()).isFalse();
+	}
+
+	@Test
+	void customChannel() throws Exception {
+		GrpcClient annotation = getAnnotation("customChannel");
+
+		assertThat(annotation.value()).isEqualTo("my-channel");
+	}
+
+	@Test
+	void withInterceptorTypes() throws Exception {
+		GrpcClient annotation = getAnnotation("withInterceptors");
+
+		assertThat(annotation.interceptors()).containsExactly(TestInterceptor.class);
+	}
+
+	@Test
+	void withInterceptorNames() throws Exception {
+		GrpcClient annotation = getAnnotation("withInterceptorNames");
+
+		assertThat(annotation.interceptorNames()).containsExactly("interceptor1", "interceptor2");
+	}
+
+	@Test
+	void withBlendInterceptors() throws Exception {
+		GrpcClient annotation = getAnnotation("withBlend");
+
+		assertThat(annotation.blendWithGlobalInterceptors()).isTrue();
+	}
+
+	private GrpcClient getAnnotation(String fieldName) throws Exception {
+		Field field = TestBean.class.getDeclaredField(fieldName);
+		return field.getAnnotation(GrpcClient.class);
+	}
+
+	static class TestBean {
+
+		@GrpcClient
+		Channel defaultChannel;
+
+		@GrpcClient("my-channel")
+		Channel customChannel;
+
+		@GrpcClient(interceptors = TestInterceptor.class)
+		Channel withInterceptors;
+
+		@GrpcClient(interceptorNames = { "interceptor1", "interceptor2" })
+		Channel withInterceptorNames;
+
+		@GrpcClient(blendWithGlobalInterceptors = true)
+		Channel withBlend;
+
+	}
+
+	static class TestInterceptor implements ClientInterceptor {
+
+		@Override
+		public <ReqT, RespT> io.grpc.ClientCall<ReqT, RespT> interceptCall(io.grpc.MethodDescriptor<ReqT, RespT> method,
+				io.grpc.CallOptions callOptions, Channel next) {
+			return next.newCall(method, callOptions);
+		}
+
+	}
+
+}


### PR DESCRIPTION
Introduce @GrpcClient annotation to simplify gRPC client creation via field and setter injection. This provides an alternative to manual constructor injection with GrpcChannelFactory.

Signed-off-by: Oleksandr Shevchenko <shevchenko.olexandr96@gmail.com>

[resolves #348]