### PR TITLE
Fix `GrpcClientRegistrationSpec#packageClasses`

### DIFF
--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/GrpcClientFactory.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/GrpcClientFactory.java
@@ -325,11 +325,8 @@ public class GrpcClientFactory implements ApplicationContextAware {
 
 		public GrpcClientRegistrationSpec packageClasses(Class<?>... packageClasses) {
 			String[] packages = new String[packageClasses.length];
-			for (Class<?> basePackageClass : packageClasses) {
-				for (int i = 0; i < packageClasses.length; i++) {
-					String basePackage = ClassUtils.getPackageName(basePackageClass);
-					packages[i] = basePackage;
-				}
+			for (int i = 0; i < packageClasses.length; i++) {
+				packages[i] = ClassUtils.getPackageName(packageClasses[i]);
 			}
 			return packages(packages);
 		}

--- a/spring-grpc-core/src/test/java/org/springframework/grpc/client/bar/Bar.java
+++ b/spring-grpc-core/src/test/java/org/springframework/grpc/client/bar/Bar.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.grpc.client.bar;
+
+/**
+ * Simple test record used to help test {@code GrpcClientRegistrationSpec} in
+ * {@code GrpcClientFactoryTests}.
+ *
+ * @param msg some context that can be used to differentiate instances
+ */
+public record Bar(String msg) {
+}

--- a/spring-grpc-core/src/test/java/org/springframework/grpc/client/foo/ExtraFoo.java
+++ b/spring-grpc-core/src/test/java/org/springframework/grpc/client/foo/ExtraFoo.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.grpc.client.foo;
+
+/**
+ * Simple test record used to help test {@code GrpcClientRegistrationSpec} in
+ * {@code GrpcClientFactoryTests}.
+ *
+ * @param msg some context that can be used to differentiate instances
+ */
+public record ExtraFoo(String msg) {
+}

--- a/spring-grpc-core/src/test/java/org/springframework/grpc/client/foo/Foo.java
+++ b/spring-grpc-core/src/test/java/org/springframework/grpc/client/foo/Foo.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.grpc.client.foo;
+
+/**
+ * Simple test record used to help test {@code GrpcClientRegistrationSpec} in
+ * {@code GrpcClientFactoryTests}.
+ *
+ * @param msg some context that can be used to differentiate instances
+ */
+public record Foo(String msg) {
+}

--- a/src/checkstyle/checkstyle-suppressions.xml
+++ b/src/checkstyle/checkstyle-suppressions.xml
@@ -8,7 +8,8 @@
 	<suppress files="Proto" checks=".*"/>
 	<suppress files=".*Tests" checks="HideUtilityClassConstructor" />
 	<suppress files=".*Tests" checks="RegexpSinglelineJava" id="toLowerCaseWithoutLocale"/>
-	<suppress files=".*Tests" checks="RegexpSinglelineJava" id="toUpperCaseWithoutLocale"/>
+	<suppress files="GrpcClientFactoryTests" checks="RegexpSinglelineJava" id="toUpperCaseWithoutLocale"/>
+	<suppress files="" checks="RedundantModifier" />
 	<suppress files="[\\/]spring-grpc-docs[\\/]" checks="JavadocPackage|JavadocType|JavadocVariable|SpringDeprecatedCheck" />
 	<suppress files="[\\/]spring-grpc-docs[\\/]" checks="SpringJavadoc" message="\@since" />
 	<suppress files="[\\/]spring-grpc-docs[\\/].*jooq" checks="AvoidStaticImport" />


### PR DESCRIPTION
Fixes the `packageClasses` method so that it does not overwrite the other packages. If you pass in A.class and B.class (from separate packages) a string array w/ each class base package string is now returned.

Fixes #361

@PARKPARKWOO PTAL