### PR TITLE
Do not re-fetch security context in auth interceptor

### DIFF
--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/AuthenticationProcessInterceptor.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/AuthenticationProcessInterceptor.java
@@ -96,11 +96,10 @@ public class AuthenticationProcessInterceptor implements ServerInterceptor, Orde
 			throw new BadCredentialsException("not authenticated");
 		}
 
-		SecurityContext currentContext = SecurityContextHolder.getContext();
 		try {
-			Context context = Context.current().withValue(GrpcSecurity.SECURITY_CONTEXT_KEY, currentContext);
+			Context context = Context.current().withValue(GrpcSecurity.SECURITY_CONTEXT_KEY, securityContext);
 			return new SecurityContextHandlerListener<ReqT, RespT>(Contexts.interceptCall(context, call, headers, next),
-					currentContext);
+					securityContext);
 		}
 		finally {
 			SecurityContextHolder.clearContext();


### PR DESCRIPTION
In the `AuthenticationProcessInterceptor` the security context was being re-fetched from the holder. While this should not cause any issues, it was surfacing an issue in a user's custom service that is using the context propagation library. While this is somewhat of a workaround, the re-fetch should not be necessary and it unblocks the user from upgrading from Spring gRPC 0.7.0 to 1.0.x.

See #360