### PR TITLE
Fix Maven command syntax in CI workflow

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -30,7 +30,7 @@ jobs:
           cache: maven
       - name: Build, test, and run samples (Java ${{ matrix.javaVersion }} ${{ matrix.distribution }})
         run: |
-          ./mvnw -B clean install-Dgpg.skip=true
+          ./mvnw -B clean install -Dgpg.skip=true
       - name: Upload Build Reports (Java ${{ matrix.javaVersion }} ${{ matrix.distribution }})
         if: failure()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Add missing space between 'install' and '-Dgpg.skip=true' to fix lifecycle phase error in CI builds.

CI build is [broken](https://github.com/spring-projects/spring-grpc/actions/runs/21711024135/job/62614362084?pr=369)
```
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  10.423 s
[INFO] Finished at: 2026-02-05T12:13:25Z
[INFO] ------------------------------------------------------------------------
Error:  Unknown lifecycle phase "install-Dgpg.skip=true". You must specify a valid lifecycle phase or a goal in the format <plugin-prefix>:<goal> or <plugin-group-id>:<plugin-artifact-id>[:<plugin-version>]:<goal>. Available lifecycle phases are: pre-clean, clean, post-clean, validate, initialize, generate-sources, process-sources, generate-resources, process-resources, compile, process-classes, generate-test-sources, process-test-sources, generate-test-resources, process-test-resources, test-compile, process-test-classes, test, prepare-package, package, pre-integration-test, integration-test, post-integration-test, verify, install, deploy, pre-site, site, post-site, site-deploy. -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/LifecyclePhaseNotFoundException
Error: Process completed with exit code 1.
```