### PR TITLE
Add anchor id for `Create a Ticket`

### DIFF
--- a/spring-grpc-docs/src/main/antora/modules/ROOT/pages/contribution-guidelines.adoc
+++ b/spring-grpc-docs/src/main/antora/modules/ROOT/pages/contribution-guidelines.adoc
@@ -12,9 +12,10 @@ In this scenario the nullability constraints will not be validated locally but r
 
 Before submitting a PR, please run the following commands to ensure proper formatting and Javadoc processing
 
-```
+[source,shell]
+----
 ./mvnw spring-javaformat:apply javadoc:javadoc -Pjavadoc
-```
+----
 
 The `-Pjavadoc` is a profile that enables Javadoc processing so as to avoid a long build time when developing.
 
@@ -54,6 +55,7 @@ Find an existing discussion or start a new one if necessary.
 If you suspect an issue, perform a search in the GitHub tracker of the Spring gRPC project, using a few different keywords.
 When you find related issues and discussions, prior or current, it helps you to learn and it helps us to make a decision.
 
+[[create-a-ticket]]
 === Create a Ticket
 
 Reporting an issue or making a feature request is a great way to contribute.


### PR DESCRIPTION
Without an anchor ID, the [create a ticket](https://docs.spring.io/spring-grpc/reference/contribution-guidelines.html#create-a-ticket) link does not point to the `Create a Ticket` section.

>2. For all but the most trivial of contributions, please [create a ticket](https://docs.spring.io/spring-grpc/reference/contribution-guidelines.html#create-a-ticket).

Reference
https://docs.spring.io/spring-grpc/reference/contribution-guidelines.html#create-a-ticket