### PR TITLE
Add logging for gRPC server address and port on startup

### DIFF
--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/lifecycle/GrpcServerLifecycle.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/lifecycle/GrpcServerLifecycle.java
@@ -126,7 +126,7 @@ public class GrpcServerLifecycle implements SmartLifecycle {
 				this.server = localServer.start();
 				final String address = this.server.getListenSockets().toString();
 				final int port = this.server.getPort();
-				logger.info("gRPC Server started, listening on address: " + this.server.getListenSockets());
+				logger.info("gRPC Server started, listening on address: " + address + ", port: " + port);
 				this.eventPublisher.publishEvent(new GrpcServerStartedEvent(this, localServer, address, port));
 
 				// Prevent the JVM from shutting down while the server is running


### PR DESCRIPTION
Closes #49049
This updates GrpcServerLifecycle startup logging to include both resolved listen address and resolved port in the same INFO log line