### PR TITLE
Fix duplicated word in GrpcServerStartedEvent Javadoc

### DIFF
--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/lifecycle/GrpcServerStartedEvent.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/lifecycle/GrpcServerStartedEvent.java
@@ -70,7 +70,7 @@ public class GrpcServerStartedEvent extends GrpcServerLifecycleEvent {
 	}
 
 	/**
-	 * Gets the address the server server was started with.
+	 * Gets the address the server was started with.
 	 * @return The address to use.
 	 */
 	public String getAddress() {


### PR DESCRIPTION
Fix a small Javadoc typo in GrpcServerStartedEvent.

The phrase "server server" appeared in the getAddress() documentation.