### PR TITLE
Apply keepalive settings only when `enableKeepAlive` is true

### DIFF
--- a/spring-grpc-client-spring-boot-autoconfigure/src/main/java/org/springframework/boot/grpc/client/autoconfigure/ClientPropertiesChannelBuilderCustomizer.java
+++ b/spring-grpc-client-spring-boot-autoconfigure/src/main/java/org/springframework/boot/grpc/client/autoconfigure/ClientPropertiesChannelBuilderCustomizer.java
@@ -37,6 +37,7 @@ import io.grpc.ManagedChannelBuilder;
  * @param <T> the type of the builder
  * @author David Syer
  * @author Chris Bono
+ * @author Andrey Litvitski
  */
 class ClientPropertiesChannelBuilderCustomizer<T extends ManagedChannelBuilder<T>>
 		implements GrpcChannelBuilderCustomizer<T> {
@@ -55,12 +56,14 @@ class ClientPropertiesChannelBuilderCustomizer<T extends ManagedChannelBuilder<T
 		if (targetAllowsLoadBalancer(target)) {
 			mapper.from(channel.getDefaultLoadBalancingPolicy()).to(builder::defaultLoadBalancingPolicy);
 		}
+		if (channel.isEnableKeepAlive()) {
+			mapper.from(channel.getKeepAliveTime()).to(durationProperty(builder::keepAliveTime));
+			mapper.from(channel.getKeepAliveTimeout()).to(durationProperty(builder::keepAliveTimeout));
+			mapper.from(channel.isKeepAliveWithoutCalls()).to(builder::keepAliveWithoutCalls);
+		}
 		mapper.from(channel.getMaxInboundMessageSize()).asInt(DataSize::toBytes).to(builder::maxInboundMessageSize);
 		mapper.from(channel.getMaxInboundMetadataSize()).asInt(DataSize::toBytes).to(builder::maxInboundMetadataSize);
-		mapper.from(channel.getKeepAliveTime()).to(durationProperty(builder::keepAliveTime));
-		mapper.from(channel.getKeepAliveTimeout()).to(durationProperty(builder::keepAliveTimeout));
 		mapper.from(channel.getIdleTimeout()).to(durationProperty(builder::idleTimeout));
-		mapper.from(channel.isKeepAliveWithoutCalls()).to(builder::keepAliveWithoutCalls);
 		Map<String, Object> defaultServiceConfig = channel.extractServiceConfig();
 		if (channel.getHealth().isEnabled()) {
 			String serviceNameToCheck = (channel.getHealth().getServiceName() != null)

--- a/spring-grpc-client-spring-boot-autoconfigure/src/test/java/org/springframework/boot/grpc/client/autoconfigure/GrpcClientAutoConfigurationTests.java
+++ b/spring-grpc-client-spring-boot-autoconfigure/src/test/java/org/springframework/boot/grpc/client/autoconfigure/GrpcClientAutoConfigurationTests.java
@@ -17,6 +17,9 @@
 package org.springframework.boot.grpc.client.autoconfigure;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.inOrder;
@@ -63,6 +66,7 @@ import io.grpc.stub.AbstractStub;
  * Tests for {@link GrpcClientAutoConfiguration}.
  *
  * @author Chris Bono
+ * @author Andrey Litvitski
  */
 @SuppressWarnings({ "unchecked" })
 class GrpcClientAutoConfigurationTests {
@@ -244,6 +248,21 @@ class GrpcClientAutoConfigurationTests {
 			assertThat(customizers).containsSequence(UserClientPropsCustomizerConfig.CUSTOMIZER_PRE_CLIENT_PROPS,
 					clientPropsCustomizer, UserClientPropsCustomizerConfig.CUSTOMIZER_POST_CLIENT_PROPS);
 		});
+	}
+
+	@Test
+	void keepAliveSettingsNotAppliedWhenDisabled() {
+		this.contextRunner()
+			.withPropertyValues("spring.grpc.client.default-channel.enable-keep-alive=false")
+			.run((context) -> {
+				var customizer = context.getBean("clientPropertiesChannelCustomizer",
+						GrpcChannelBuilderCustomizer.class);
+				ManagedChannelBuilder<?> builder = Mockito.mock();
+				customizer.customize("default", builder);
+				then(builder).should(never()).keepAliveTime(anyLong(), any());
+				then(builder).should(never()).keepAliveTimeout(anyLong(), any());
+				then(builder).should(never()).keepAliveWithoutCalls(anyBoolean());
+			});
 	}
 
 	@Test


### PR DESCRIPTION
This commit fixes an issue where we were applying keep-alive settings even when we had disabled the feature.

Closes: spring-projects/spring-boot#49829