### PR TITLE
Add Spring Cloud discovery name resolver support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 		<!-- Spring gRPC modules -->
 		<module>spring-grpc-build-dependencies</module>
 		<module>spring-grpc-core</module>
+		<module>spring-grpc-spring-cloud</module>
 		<module>spring-grpc-dependencies</module>
 		<module>spring-grpc-docs</module>
 <!--		<module>samples</module>-->

--- a/spring-grpc-build-dependencies/pom.xml
+++ b/spring-grpc-build-dependencies/pom.xml
@@ -54,6 +54,8 @@
 		<grpc-kotlin.version>1.5.0</grpc-kotlin.version>
 		<jspecify.version>1.0.0</jspecify.version>
 		<protobuf-java.version>4.34.0</protobuf-java.version>
+		<spring-boot.version>4.1.0-SNAPSHOT</spring-boot.version>
+		<spring-cloud-commons.version>5.0.1</spring-cloud-commons.version>
 		<spring-framework.version>7.0.6</spring-framework.version>
 		<spring-security.version>7.1.0-M2</spring-security.version>
 		<micrometer.version>1.17.0-M3</micrometer.version>
@@ -98,6 +100,21 @@
 				<version>${micrometer.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-autoconfigure</artifactId>
+				<version>${spring-boot.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-configuration-processor</artifactId>
+				<version>${spring-boot.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-commons</artifactId>
+				<version>${spring-cloud-commons.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.jspecify</groupId>

--- a/spring-grpc-dependencies/pom.xml
+++ b/spring-grpc-dependencies/pom.xml
@@ -64,6 +64,11 @@
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
+				<groupId>org.springframework.grpc</groupId>
+				<artifactId>spring-grpc-spring-cloud</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
 				<groupId>com.google.protobuf</groupId>
 				<artifactId>protoc</artifactId>
 				<version>${protobuf-java.version}</version>

--- a/spring-grpc-docs/src/main/antora/modules/ROOT/pages/client.adoc
+++ b/spring-grpc-docs/src/main/antora/modules/ROOT/pages/client.adoc
@@ -146,6 +146,41 @@ NOTE: To use the inprocess server the channel target must be set to `in-process:
 
 To disable the inprocess channel factory, you can set the `spring.grpc.client.inprocess.enabled` property to false.
 
+== Spring Cloud Discovery
+
+If you want to resolve gRPC clients through Spring Cloud `DiscoveryClient`, add the
+`spring-grpc-spring-cloud` module to your application.
+
+[source,xml]
+----
+<dependency>
+	<groupId>org.springframework.grpc</groupId>
+	<artifactId>spring-grpc-spring-cloud</artifactId>
+</dependency>
+----
+
+Then configure the channel target with the `discovery` scheme:
+
+[source,properties]
+----
+spring.grpc.client.channels.orders.address=discovery:///orders-service
+----
+
+By default the discovery resolver applies the `round_robin` load-balancing policy to
+resolved addresses.
+You can customize or disable that integration with:
+
+[source,properties]
+----
+spring.grpc.client.discovery.enabled=true
+spring.grpc.client.discovery.load-balancing-policy=round_robin
+----
+
+Each resolved service instance uses the `gRPC_port` metadata entry when present and
+falls back to the regular instance port otherwise.
+Discovery-based channels are refreshed automatically when Spring Cloud publishes a
+`HeartbeatEvent`.
+
 == Channel Configuration
 The channel factory provides an API to create channels.
 The channel creation process can be configured as follows.

--- a/spring-grpc-docs/src/main/antora/modules/ROOT/pages/client.adoc
+++ b/spring-grpc-docs/src/main/antora/modules/ROOT/pages/client.adoc
@@ -178,6 +178,16 @@ spring.grpc.client.discovery.load-balancing-policy=round_robin
 
 Each resolved service instance uses the `gRPC_port` metadata entry when present and
 falls back to the regular instance port otherwise.
+When the same module is used in a gRPC server application with Spring Cloud service
+registration, it also publishes the configured `spring.grpc.server.port` as
+`gRPC_port` metadata when the underlying `Registration` exposes mutable metadata.
+You can disable that behavior with:
+
+[source,properties]
+----
+spring.grpc.server.discovery.publish-metadata=false
+----
+
 Discovery-based channels are refreshed automatically when Spring Cloud publishes a
 `HeartbeatEvent`.
 

--- a/spring-grpc-spring-cloud/pom.xml
+++ b/spring-grpc-spring-cloud/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.grpc</groupId>
+		<artifactId>spring-grpc</artifactId>
+		<version>1.1.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>spring-grpc-spring-cloud</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring gRPC Spring Cloud</name>
+	<description>Spring Cloud DiscoveryClient integration for Spring gRPC clients</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.grpc</groupId>
+			<artifactId>spring-grpc-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-commons</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jspecify</groupId>
+			<artifactId>jspecify</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/spring-grpc-spring-cloud/src/main/java/org/springframework/grpc/client/discovery/DiscoveryClientNameResolverProvider.java
+++ b/spring-grpc-spring-cloud/src/main/java/org/springframework/grpc/client/discovery/DiscoveryClientNameResolverProvider.java
@@ -26,6 +26,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
 
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
@@ -61,7 +62,7 @@ public class DiscoveryClientNameResolverProvider extends NameResolverProvider {
 	}
 
 	@Override
-	public NameResolver newNameResolver(URI targetUri, NameResolver.Args args) {
+	public @Nullable NameResolver newNameResolver(URI targetUri, NameResolver.Args args) {
 		if (!GrpcDiscoveryConstants.DISCOVERY_SCHEME.equals(targetUri.getScheme())) {
 			return null;
 		}
@@ -92,7 +93,7 @@ public class DiscoveryClientNameResolverProvider extends NameResolverProvider {
 			.forEach((resolvers) -> resolvers.forEach((resolver) -> resolver.resolveNow(reason)));
 	}
 
-	private static String extractServiceName(URI targetUri) {
+	private static @Nullable String extractServiceName(URI targetUri) {
 		String path = targetUri.getPath();
 		if (StringUtils.hasText(path)) {
 			return (path.startsWith("/")) ? path.substring(1) : path;
@@ -121,9 +122,9 @@ public class DiscoveryClientNameResolverProvider extends NameResolverProvider {
 
 		private final Args args;
 
-		private volatile Listener2 listener;
+		private volatile @Nullable Listener2 listener;
 
-		private volatile ResolutionResult lastResolutionResult;
+		private volatile @Nullable ResolutionResult lastResolutionResult;
 
 		private DiscoveryClientNameResolver(String serviceName, Args args) {
 			this.serviceName = serviceName;
@@ -153,7 +154,8 @@ public class DiscoveryClientNameResolverProvider extends NameResolverProvider {
 		}
 
 		private void resolveNow(String reason) {
-			if (this.listener == null) {
+			Listener2 listener = this.listener;
+			if (listener == null) {
 				return;
 			}
 			Executor executor = this.args.getOffloadExecutor();
@@ -173,7 +175,7 @@ public class DiscoveryClientNameResolverProvider extends NameResolverProvider {
 					}
 					ResolutionResult result = resultBuilder.build();
 					this.lastResolutionResult = result;
-					this.args.getSynchronizationContext().execute(() -> this.listener.onResult(result));
+					this.args.getSynchronizationContext().execute(() -> listener.onResult(result));
 				}
 				catch (RuntimeException ex) {
 					handleResolutionError(reason, ex);
@@ -197,7 +199,10 @@ public class DiscoveryClientNameResolverProvider extends NameResolverProvider {
 				.warn(() -> "No instances found for discovery target. serviceName=" + this.serviceName + ", reason="
 						+ reason);
 			Status status = Status.UNAVAILABLE.withDescription("No instance for " + this.serviceName);
-			this.args.getSynchronizationContext().execute(() -> this.listener.onError(status));
+			Listener2 listener = this.listener;
+			if (listener != null) {
+				this.args.getSynchronizationContext().execute(() -> listener.onError(status));
+			}
 		}
 
 		private void handleResolutionError(String reason, RuntimeException ex) {
@@ -206,10 +211,13 @@ public class DiscoveryClientNameResolverProvider extends NameResolverProvider {
 			Status status = Status.UNAVAILABLE
 				.withDescription("Failed to resolve discovery target '" + this.serviceName + "'")
 				.withCause(ex);
-			this.args.getSynchronizationContext().execute(() -> this.listener.onError(status));
+			Listener2 listener = this.listener;
+			if (listener != null) {
+				this.args.getSynchronizationContext().execute(() -> listener.onError(status));
+			}
 		}
 
-		private ConfigOrError buildServiceConfig() {
+		private @Nullable ConfigOrError buildServiceConfig() {
 			String policy = DiscoveryClientNameResolverProvider.this.properties.getLoadBalancingPolicy();
 			if (!StringUtils.hasText(policy)) {
 				return null;
@@ -229,7 +237,8 @@ public class DiscoveryClientNameResolverProvider extends NameResolverProvider {
 		}
 
 		private int resolveGrpcPort(ServiceInstance instance) {
-			String grpcPort = instance.getMetadata().get(GrpcDiscoveryConstants.GRPC_PORT_METADATA_KEY);
+			Map<String, String> metadata = instance.getMetadata();
+			String grpcPort = (metadata != null) ? metadata.get(GrpcDiscoveryConstants.GRPC_PORT_METADATA_KEY) : null;
 			if (!StringUtils.hasText(grpcPort)) {
 				return instance.getPort();
 			}

--- a/spring-grpc-spring-cloud/src/main/java/org/springframework/grpc/client/discovery/DiscoveryClientNameResolverProvider.java
+++ b/spring-grpc-spring-cloud/src/main/java/org/springframework/grpc/client/discovery/DiscoveryClientNameResolverProvider.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.grpc.client.discovery;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executor;
+
+import org.jspecify.annotations.NullMarked;
+
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.core.log.LogAccessor;
+import org.springframework.util.StringUtils;
+
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.NameResolver;
+import io.grpc.NameResolverProvider;
+import io.grpc.Status;
+
+/**
+ * {@link NameResolverProvider} that resolves {@code discovery:///service-name} targets
+ * through Spring Cloud {@link DiscoveryClient}.
+ *
+ * @author Hyacinth Contributor
+ */
+@NullMarked
+public class DiscoveryClientNameResolverProvider extends NameResolverProvider {
+
+	private final LogAccessor logger = new LogAccessor(getClass());
+
+	private final DiscoveryClient discoveryClient;
+
+	private final DiscoveryClientResolverProperties properties;
+
+	private final Map<String, CopyOnWriteArrayList<DiscoveryClientNameResolver>> activeResolvers = new ConcurrentHashMap<>();
+
+	public DiscoveryClientNameResolverProvider(DiscoveryClient discoveryClient,
+			DiscoveryClientResolverProperties properties) {
+		this.discoveryClient = discoveryClient;
+		this.properties = properties;
+	}
+
+	@Override
+	public NameResolver newNameResolver(URI targetUri, NameResolver.Args args) {
+		if (!GrpcDiscoveryConstants.DISCOVERY_SCHEME.equals(targetUri.getScheme())) {
+			return null;
+		}
+		String serviceName = extractServiceName(targetUri);
+		if (!StringUtils.hasText(serviceName)) {
+			return null;
+		}
+		return new DiscoveryClientNameResolver(serviceName, args);
+	}
+
+	@Override
+	public String getDefaultScheme() {
+		return GrpcDiscoveryConstants.DISCOVERY_SCHEME;
+	}
+
+	@Override
+	protected boolean isAvailable() {
+		return true;
+	}
+
+	@Override
+	protected int priority() {
+		return 6;
+	}
+
+	public void refreshAll(String reason) {
+		this.activeResolvers.values()
+			.forEach((resolvers) -> resolvers.forEach((resolver) -> resolver.resolveNow(reason)));
+	}
+
+	private static String extractServiceName(URI targetUri) {
+		String path = targetUri.getPath();
+		if (StringUtils.hasText(path)) {
+			return (path.startsWith("/")) ? path.substring(1) : path;
+		}
+		return targetUri.getAuthority();
+	}
+
+	private void register(String serviceName, DiscoveryClientNameResolver resolver) {
+		this.activeResolvers.computeIfAbsent(serviceName, (key) -> new CopyOnWriteArrayList<>()).add(resolver);
+	}
+
+	private void unregister(String serviceName, DiscoveryClientNameResolver resolver) {
+		CopyOnWriteArrayList<DiscoveryClientNameResolver> resolvers = this.activeResolvers.get(serviceName);
+		if (resolvers == null) {
+			return;
+		}
+		resolvers.remove(resolver);
+		if (resolvers.isEmpty()) {
+			this.activeResolvers.remove(serviceName, resolvers);
+		}
+	}
+
+	private final class DiscoveryClientNameResolver extends NameResolver {
+
+		private final String serviceName;
+
+		private final Args args;
+
+		private volatile Listener2 listener;
+
+		private volatile ResolutionResult lastResolutionResult;
+
+		private DiscoveryClientNameResolver(String serviceName, Args args) {
+			this.serviceName = serviceName;
+			this.args = args;
+		}
+
+		@Override
+		public String getServiceAuthority() {
+			return this.serviceName;
+		}
+
+		@Override
+		public void start(Listener2 listener) {
+			this.listener = listener;
+			register(this.serviceName, this);
+			resolveNow("startup");
+		}
+
+		@Override
+		public void refresh() {
+			resolveNow("grpc-refresh");
+		}
+
+		@Override
+		public void shutdown() {
+			unregister(this.serviceName, this);
+		}
+
+		private void resolveNow(String reason) {
+			if (this.listener == null) {
+				return;
+			}
+			Executor executor = this.args.getOffloadExecutor();
+			Runnable resolveTask = () -> {
+				try {
+					List<ServiceInstance> instances = DiscoveryClientNameResolverProvider.this.discoveryClient
+						.getInstances(this.serviceName);
+					if (instances == null || instances.isEmpty()) {
+						handleNoInstances(reason);
+						return;
+					}
+					ResolutionResult.Builder resultBuilder = ResolutionResult.newBuilder()
+						.setAddresses(instances.stream().map(this::toAddressGroup).toList());
+					ConfigOrError serviceConfig = buildServiceConfig();
+					if (serviceConfig != null) {
+						resultBuilder.setServiceConfig(serviceConfig);
+					}
+					ResolutionResult result = resultBuilder.build();
+					this.lastResolutionResult = result;
+					this.args.getSynchronizationContext().execute(() -> this.listener.onResult(result));
+				}
+				catch (RuntimeException ex) {
+					handleResolutionError(reason, ex);
+				}
+			};
+			if (executor != null) {
+				executor.execute(resolveTask);
+				return;
+			}
+			resolveTask.run();
+		}
+
+		private void handleNoInstances(String reason) {
+			if (this.lastResolutionResult != null) {
+				DiscoveryClientNameResolverProvider.this.logger
+					.warn(() -> "No instances found for discovery target, keeping previous resolution. serviceName="
+							+ this.serviceName + ", reason=" + reason);
+				return;
+			}
+			DiscoveryClientNameResolverProvider.this.logger
+				.warn(() -> "No instances found for discovery target. serviceName=" + this.serviceName + ", reason="
+						+ reason);
+			Status status = Status.UNAVAILABLE.withDescription("No instance for " + this.serviceName);
+			this.args.getSynchronizationContext().execute(() -> this.listener.onError(status));
+		}
+
+		private void handleResolutionError(String reason, RuntimeException ex) {
+			DiscoveryClientNameResolverProvider.this.logger.error(ex,
+					() -> "Failed to resolve discovery target. serviceName=" + this.serviceName + ", reason=" + reason);
+			Status status = Status.UNAVAILABLE
+				.withDescription("Failed to resolve discovery target '" + this.serviceName + "'")
+				.withCause(ex);
+			this.args.getSynchronizationContext().execute(() -> this.listener.onError(status));
+		}
+
+		private ConfigOrError buildServiceConfig() {
+			String policy = DiscoveryClientNameResolverProvider.this.properties.getLoadBalancingPolicy();
+			if (!StringUtils.hasText(policy)) {
+				return null;
+			}
+			Map<String, ?> serviceConfig = Map.of("loadBalancingConfig",
+					List.of(Map.of(policy, Collections.emptyMap())));
+			return this.args.getServiceConfigParser().parseServiceConfig(serviceConfig);
+		}
+
+		private EquivalentAddressGroup toAddressGroup(ServiceInstance instance) {
+			int grpcPort = resolveGrpcPort(instance);
+			String host = instance.getHost();
+			DiscoveryClientNameResolverProvider.this.logger
+				.debug(() -> "Discovery resolver selected instance. serviceName=" + this.serviceName + ", host=" + host
+						+ ", grpcPort=" + grpcPort + ", metadata=" + instance.getMetadata());
+			return new EquivalentAddressGroup(new InetSocketAddress(host, grpcPort));
+		}
+
+		private int resolveGrpcPort(ServiceInstance instance) {
+			String grpcPort = instance.getMetadata().get(GrpcDiscoveryConstants.GRPC_PORT_METADATA_KEY);
+			if (!StringUtils.hasText(grpcPort)) {
+				return instance.getPort();
+			}
+			try {
+				return Integer.parseInt(grpcPort);
+			}
+			catch (NumberFormatException ex) {
+				DiscoveryClientNameResolverProvider.this.logger
+					.warn(() -> "Invalid metadata.gRPC_port detected, fallback to instance port. serviceName="
+							+ this.serviceName + ", host=" + instance.getHost() + ", value=" + grpcPort);
+				return instance.getPort();
+			}
+		}
+
+	}
+
+}

--- a/spring-grpc-spring-cloud/src/main/java/org/springframework/grpc/client/discovery/DiscoveryClientResolverProperties.java
+++ b/spring-grpc-spring-cloud/src/main/java/org/springframework/grpc/client/discovery/DiscoveryClientResolverProperties.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.grpc.client.discovery;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for discovery-backed gRPC channels.
+ *
+ * @author Hyacinth Contributor
+ */
+@ConfigurationProperties(prefix = "spring.grpc.client.discovery")
+public class DiscoveryClientResolverProperties {
+
+	/**
+	 * Whether Spring Cloud discovery-backed channel resolution is enabled.
+	 */
+	private boolean enabled = true;
+
+	/**
+	 * Load-balancing policy applied to discovery-based channels.
+	 */
+	private String loadBalancingPolicy = "round_robin";
+
+	public boolean isEnabled() {
+		return this.enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	public String getLoadBalancingPolicy() {
+		return this.loadBalancingPolicy;
+	}
+
+	public void setLoadBalancingPolicy(String loadBalancingPolicy) {
+		this.loadBalancingPolicy = loadBalancingPolicy;
+	}
+
+}

--- a/spring-grpc-spring-cloud/src/main/java/org/springframework/grpc/client/discovery/DiscoveryNameResolverRefresher.java
+++ b/spring-grpc-spring-cloud/src/main/java/org/springframework/grpc/client/discovery/DiscoveryNameResolverRefresher.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.grpc.client.discovery;
+
+import org.springframework.cloud.client.discovery.event.HeartbeatEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.log.LogAccessor;
+
+/**
+ * Refreshes discovery-backed resolvers when the Spring Cloud registry changes.
+ *
+ * @author Hyacinth Contributor
+ */
+public class DiscoveryNameResolverRefresher {
+
+	private final LogAccessor logger = new LogAccessor(getClass());
+
+	private final DiscoveryClientNameResolverProvider provider;
+
+	public DiscoveryNameResolverRefresher(DiscoveryClientNameResolverProvider provider) {
+		this.provider = provider;
+	}
+
+	@EventListener(HeartbeatEvent.class)
+	public void onHeartbeat(HeartbeatEvent event) {
+		this.logger.debug(() -> "Received HeartbeatEvent, refreshing discovery resolvers. value=" + event.getValue());
+		this.provider.refreshAll("heartbeat-event");
+	}
+
+}

--- a/spring-grpc-spring-cloud/src/main/java/org/springframework/grpc/client/discovery/DiscoveryNameResolverRegistrar.java
+++ b/spring-grpc-spring-cloud/src/main/java/org/springframework/grpc/client/discovery/DiscoveryNameResolverRegistrar.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.grpc.client.discovery;
+
+import org.jspecify.annotations.NullMarked;
+
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.core.log.LogAccessor;
+
+import io.grpc.NameResolverRegistry;
+
+/**
+ * Registers a discovery-backed {@link io.grpc.NameResolverProvider} with the gRPC
+ * registry.
+ *
+ * @author Hyacinth Contributor
+ */
+@NullMarked
+public class DiscoveryNameResolverRegistrar implements InitializingBean, DisposableBean {
+
+	private final LogAccessor logger = new LogAccessor(getClass());
+
+	private final DiscoveryClientNameResolverProvider provider;
+
+	public DiscoveryNameResolverRegistrar(DiscoveryClientNameResolverProvider provider) {
+		this.provider = provider;
+	}
+
+	@Override
+	public void afterPropertiesSet() {
+		NameResolverRegistry.getDefaultRegistry().register(this.provider);
+		this.logger.info(() -> "Registered discovery NameResolverProvider for scheme '"
+				+ GrpcDiscoveryConstants.DISCOVERY_SCHEME + "'");
+	}
+
+	@Override
+	public void destroy() {
+		NameResolverRegistry.getDefaultRegistry().deregister(this.provider);
+	}
+
+}

--- a/spring-grpc-spring-cloud/src/main/java/org/springframework/grpc/client/discovery/DiscoveryNameResolverRegistrarBeanFactoryPostProcessor.java
+++ b/spring-grpc-spring-cloud/src/main/java/org/springframework/grpc/client/discovery/DiscoveryNameResolverRegistrarBeanFactoryPostProcessor.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.grpc.client.discovery;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.grpc.client.GrpcChannelFactory;
+
+/**
+ * Ensures {@link DiscoveryNameResolverRegistrar} is initialized before any
+ * {@link GrpcChannelFactory} bean.
+ *
+ * @author Hyacinth Contributor
+ */
+public class DiscoveryNameResolverRegistrarBeanFactoryPostProcessor implements BeanFactoryPostProcessor {
+
+	private final String registrarBeanName;
+
+	public DiscoveryNameResolverRegistrarBeanFactoryPostProcessor(String registrarBeanName) {
+		this.registrarBeanName = registrarBeanName;
+	}
+
+	@Override
+	public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+		String[] beanNames = beanFactory.getBeanNamesForType(GrpcChannelFactory.class, false, false);
+		for (String beanName : beanNames) {
+			if (!beanFactory.containsBeanDefinition(beanName)) {
+				continue;
+			}
+			AbstractBeanDefinition beanDefinition = (AbstractBeanDefinition) beanFactory.getBeanDefinition(beanName);
+			Set<String> dependsOn = new LinkedHashSet<>();
+			String[] existingDependsOn = beanDefinition.getDependsOn();
+			if (existingDependsOn != null) {
+				dependsOn.addAll(Set.of(existingDependsOn));
+			}
+			dependsOn.add(this.registrarBeanName);
+			beanDefinition.setDependsOn(dependsOn.toArray(String[]::new));
+		}
+	}
+
+}

--- a/spring-grpc-spring-cloud/src/main/java/org/springframework/grpc/client/discovery/GrpcDiscoveryConstants.java
+++ b/spring-grpc-spring-cloud/src/main/java/org/springframework/grpc/client/discovery/GrpcDiscoveryConstants.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.grpc.client.discovery;
+
+/**
+ * Constants for discovery-backed gRPC channels.
+ *
+ * @author Hyacinth Contributor
+ */
+public final class GrpcDiscoveryConstants {
+
+	/**
+	 * URI scheme for discovery-backed channels.
+	 */
+	public static final String DISCOVERY_SCHEME = "discovery";
+
+	/**
+	 * Metadata key used to advertise the gRPC port of a service instance.
+	 */
+	public static final String GRPC_PORT_METADATA_KEY = "gRPC_port";
+
+	private GrpcDiscoveryConstants() {
+	}
+
+}

--- a/spring-grpc-spring-cloud/src/main/java/org/springframework/grpc/client/discovery/GrpcPortMetadataRegistrationBeanPostProcessor.java
+++ b/spring-grpc-spring-cloud/src/main/java/org/springframework/grpc/client/discovery/GrpcPortMetadataRegistrationBeanPostProcessor.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.grpc.client.discovery;
+
+import java.util.Map;
+
+import org.jspecify.annotations.NullMarked;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.cloud.client.serviceregistry.Registration;
+import org.springframework.core.log.LogAccessor;
+
+/**
+ * Publishes the configured gRPC server port into Spring Cloud service registration
+ * metadata when the underlying {@link Registration} exposes a mutable metadata map.
+ *
+ * @author Hyacinth Contributor
+ */
+@NullMarked
+public class GrpcPortMetadataRegistrationBeanPostProcessor implements BeanPostProcessor {
+
+	private final LogAccessor logger = new LogAccessor(getClass());
+
+	private final int grpcPort;
+
+	public GrpcPortMetadataRegistrationBeanPostProcessor(int grpcPort) {
+		this.grpcPort = grpcPort;
+	}
+
+	@Override
+	public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+		if (!(bean instanceof Registration registration)) {
+			return bean;
+		}
+		Map<String, String> metadata = registration.getMetadata();
+		if (metadata == null) {
+			this.logger
+				.debug(() -> "Registration metadata is null, skipping gRPC metadata publication. beanName=" + beanName);
+			return bean;
+		}
+		try {
+			metadata.put(GrpcDiscoveryConstants.GRPC_PORT_METADATA_KEY, String.valueOf(this.grpcPort));
+			this.logger.info(() -> "Published registration metadata " + GrpcDiscoveryConstants.GRPC_PORT_METADATA_KEY
+					+ "=" + this.grpcPort + ". beanName=" + beanName);
+		}
+		catch (UnsupportedOperationException ex) {
+			this.logger.debug(ex,
+					() -> "Registration metadata is not mutable, skipping gRPC metadata publication. beanName="
+							+ beanName);
+		}
+		return bean;
+	}
+
+}

--- a/spring-grpc-spring-cloud/src/main/java/org/springframework/grpc/client/discovery/autoconfigure/DiscoveryClientNameResolverAutoConfiguration.java
+++ b/spring-grpc-spring-cloud/src/main/java/org/springframework/grpc/client/discovery/autoconfigure/DiscoveryClientNameResolverAutoConfiguration.java
@@ -28,6 +28,7 @@ import org.springframework.grpc.client.discovery.DiscoveryClientNameResolverProv
 import org.springframework.grpc.client.discovery.DiscoveryClientResolverProperties;
 import org.springframework.grpc.client.discovery.DiscoveryNameResolverRefresher;
 import org.springframework.grpc.client.discovery.DiscoveryNameResolverRegistrar;
+import org.springframework.grpc.client.discovery.DiscoveryNameResolverRegistrarBeanFactoryPostProcessor;
 
 import io.grpc.NameResolver;
 
@@ -44,6 +45,8 @@ import io.grpc.NameResolver;
 @EnableConfigurationProperties(DiscoveryClientResolverProperties.class)
 public class DiscoveryClientNameResolverAutoConfiguration {
 
+	private static final String DISCOVERY_NAME_RESOLVER_REGISTRAR_BEAN_NAME = "discoveryNameResolverRegistrar";
+
 	@Bean
 	@ConditionalOnMissingBean
 	DiscoveryClientNameResolverProvider discoveryClientNameResolverProvider(DiscoveryClient discoveryClient,
@@ -55,6 +58,11 @@ public class DiscoveryClientNameResolverAutoConfiguration {
 	@ConditionalOnMissingBean
 	DiscoveryNameResolverRegistrar discoveryNameResolverRegistrar(DiscoveryClientNameResolverProvider provider) {
 		return new DiscoveryNameResolverRegistrar(provider);
+	}
+
+	@Bean
+	static DiscoveryNameResolverRegistrarBeanFactoryPostProcessor discoveryNameResolverRegistrarBeanFactoryPostProcessor() {
+		return new DiscoveryNameResolverRegistrarBeanFactoryPostProcessor(DISCOVERY_NAME_RESOLVER_REGISTRAR_BEAN_NAME);
 	}
 
 	@Bean

--- a/spring-grpc-spring-cloud/src/main/java/org/springframework/grpc/client/discovery/autoconfigure/DiscoveryClientNameResolverAutoConfiguration.java
+++ b/spring-grpc-spring-cloud/src/main/java/org/springframework/grpc/client/discovery/autoconfigure/DiscoveryClientNameResolverAutoConfiguration.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.grpc.client.discovery.autoconfigure;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.grpc.client.discovery.DiscoveryClientNameResolverProvider;
+import org.springframework.grpc.client.discovery.DiscoveryClientResolverProperties;
+import org.springframework.grpc.client.discovery.DiscoveryNameResolverRefresher;
+import org.springframework.grpc.client.discovery.DiscoveryNameResolverRegistrar;
+
+import io.grpc.NameResolver;
+
+/**
+ * Auto-configuration for Spring Cloud backed gRPC name resolution.
+ *
+ * @author Hyacinth Contributor
+ */
+@AutoConfiguration
+@ConditionalOnClass({ NameResolver.class, DiscoveryClient.class })
+@ConditionalOnBean(DiscoveryClient.class)
+@ConditionalOnProperty(prefix = "spring.grpc.client.discovery", name = "enabled", havingValue = "true",
+		matchIfMissing = true)
+@EnableConfigurationProperties(DiscoveryClientResolverProperties.class)
+public class DiscoveryClientNameResolverAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean
+	DiscoveryClientNameResolverProvider discoveryClientNameResolverProvider(DiscoveryClient discoveryClient,
+			DiscoveryClientResolverProperties properties) {
+		return new DiscoveryClientNameResolverProvider(discoveryClient, properties);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	DiscoveryNameResolverRegistrar discoveryNameResolverRegistrar(DiscoveryClientNameResolverProvider provider) {
+		return new DiscoveryNameResolverRegistrar(provider);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	DiscoveryNameResolverRefresher discoveryNameResolverRefresher(DiscoveryClientNameResolverProvider provider) {
+		return new DiscoveryNameResolverRefresher(provider);
+	}
+
+}

--- a/spring-grpc-spring-cloud/src/main/java/org/springframework/grpc/client/discovery/autoconfigure/GrpcDiscoveryServiceRegistryAutoConfiguration.java
+++ b/spring-grpc-spring-cloud/src/main/java/org/springframework/grpc/client/discovery/autoconfigure/GrpcDiscoveryServiceRegistryAutoConfiguration.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.grpc.client.discovery.autoconfigure;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.client.serviceregistry.Registration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.env.Environment;
+import org.springframework.grpc.client.discovery.GrpcPortMetadataRegistrationBeanPostProcessor;
+
+/**
+ * Auto-configuration for publishing gRPC server metadata through Spring Cloud service
+ * registration.
+ *
+ * @author Hyacinth Contributor
+ */
+@AutoConfiguration
+@ConditionalOnClass(Registration.class)
+@ConditionalOnProperty(prefix = "spring.grpc.server", name = "port")
+@ConditionalOnProperty(prefix = "spring.grpc.server.discovery", name = "publish-metadata", havingValue = "true",
+		matchIfMissing = true)
+public final class GrpcDiscoveryServiceRegistryAutoConfiguration {
+
+	private GrpcDiscoveryServiceRegistryAutoConfiguration() {
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	static GrpcPortMetadataRegistrationBeanPostProcessor grpcPortMetadataRegistrationBeanPostProcessor(
+			Environment environment) {
+		int grpcPort = Integer.parseInt(environment.getRequiredProperty("spring.grpc.server.port"));
+		return new GrpcPortMetadataRegistrationBeanPostProcessor(grpcPort);
+	}
+
+}

--- a/spring-grpc-spring-cloud/src/main/java/org/springframework/grpc/client/discovery/autoconfigure/package-info.java
+++ b/spring-grpc-spring-cloud/src/main/java/org/springframework/grpc/client/discovery/autoconfigure/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for Spring Cloud backed gRPC discovery.
+ */
+@NullMarked
+package org.springframework.grpc.client.discovery.autoconfigure;
+
+import org.jspecify.annotations.NullMarked;

--- a/spring-grpc-spring-cloud/src/main/java/org/springframework/grpc/client/discovery/package-info.java
+++ b/spring-grpc-spring-cloud/src/main/java/org/springframework/grpc/client/discovery/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Spring Cloud Discovery integration for gRPC clients.
+ */
+@NullMarked
+package org.springframework.grpc.client.discovery;
+
+import org.jspecify.annotations.NullMarked;

--- a/spring-grpc-spring-cloud/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-grpc-spring-cloud/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.springframework.grpc.client.discovery.autoconfigure.DiscoveryClientNameResolverAutoConfiguration

--- a/spring-grpc-spring-cloud/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-grpc-spring-cloud/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
 org.springframework.grpc.client.discovery.autoconfigure.DiscoveryClientNameResolverAutoConfiguration
+org.springframework.grpc.client.discovery.autoconfigure.GrpcDiscoveryServiceRegistryAutoConfiguration

--- a/spring-grpc-spring-cloud/src/test/java/org/springframework/grpc/client/discovery/DiscoveryClientNameResolverProviderTests.java
+++ b/spring-grpc-spring-cloud/src/test/java/org/springframework/grpc/client/discovery/DiscoveryClientNameResolverProviderTests.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.grpc.client.discovery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.assertArg;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import org.springframework.cloud.client.DefaultServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.NameResolver;
+import io.grpc.Status;
+import io.grpc.SynchronizationContext;
+
+/**
+ * Tests for {@link DiscoveryClientNameResolverProvider}.
+ */
+class DiscoveryClientNameResolverProviderTests {
+
+	@Test
+	void resolvesDiscoveryTargetAndAppliesConfiguredLoadBalancingPolicy() throws Exception {
+		DiscoveryClient discoveryClient = mock(DiscoveryClient.class);
+		DiscoveryClientResolverProperties properties = new DiscoveryClientResolverProperties();
+		when(discoveryClient.getInstances("orders-service"))
+			.thenReturn(List.of(instance("orders-service", "127.0.0.1", 8080, Map.of("gRPC_port", "9090")),
+					instance("orders-service", "127.0.0.2", 8081, Map.of())));
+		var provider = new DiscoveryClientNameResolverProvider(discoveryClient, properties);
+		var listener = mock(NameResolver.Listener2.class);
+		var resolver = provider.newNameResolver(new URI("discovery:///orders-service"), args());
+		assertThat(resolver).isNotNull();
+		resolver.start(listener);
+		verify(listener).onResult(assertArg((result) -> {
+			assertThat(result.getAddresses()).hasSize(2);
+			assertThat(result.getAddresses()).extracting(EquivalentAddressGroup::getAddresses)
+				.allSatisfy((addresses) -> {
+					assertThat(addresses).hasSize(1);
+				});
+			assertThat(result.getAddresses().get(0).getAddresses().get(0)).hasToString("/127.0.0.1:9090");
+			assertThat(result.getAddresses().get(1).getAddresses().get(0)).hasToString("/127.0.0.2:8081");
+			assertThat(result.getServiceConfig()).isNotNull();
+			assertThat(result.getServiceConfig().getConfig())
+				.isEqualTo(Map.of("loadBalancingConfig", List.of(Map.of("round_robin", Map.of()))));
+		}));
+	}
+
+	@Test
+	void keepsPreviousResolutionWhenRefreshTemporarilyReturnsNoInstances() throws Exception {
+		DiscoveryClient discoveryClient = mock(DiscoveryClient.class);
+		DiscoveryClientResolverProperties properties = new DiscoveryClientResolverProperties();
+		when(discoveryClient.getInstances("orders-service"))
+			.thenReturn(List.of(instance("orders-service", "127.0.0.1", 8080, Map.of("gRPC_port", "9090"))))
+			.thenReturn(List.of());
+		var provider = new DiscoveryClientNameResolverProvider(discoveryClient, properties);
+		var listener = mock(NameResolver.Listener2.class);
+		var resolver = provider.newNameResolver(new URI("discovery:///orders-service"), args());
+		assertThat(resolver).isNotNull();
+		resolver.start(listener);
+		resolver.refresh();
+		verify(listener, Mockito.times(1)).onResult(Mockito.any());
+		Mockito.verify(listener, Mockito.never()).onError(Mockito.any());
+	}
+
+	@Test
+	void reportsUnavailableWhenNoInstancesExistOnInitialResolution() throws Exception {
+		DiscoveryClient discoveryClient = mock(DiscoveryClient.class);
+		when(discoveryClient.getInstances("orders-service")).thenReturn(List.of());
+		var provider = new DiscoveryClientNameResolverProvider(discoveryClient,
+				new DiscoveryClientResolverProperties());
+		var listener = mock(NameResolver.Listener2.class);
+		var resolver = provider.newNameResolver(new URI("discovery:///orders-service"), args());
+		assertThat(resolver).isNotNull();
+		resolver.start(listener);
+		verify(listener).onError(assertArg((status) -> {
+			assertThat(status.getCode()).isEqualTo(Status.Code.UNAVAILABLE);
+			assertThat(status.getDescription()).isEqualTo("No instance for orders-service");
+		}));
+	}
+
+	@Test
+	void nonDiscoverySchemeReturnsNull() throws Exception {
+		var provider = new DiscoveryClientNameResolverProvider(mock(DiscoveryClient.class),
+				new DiscoveryClientResolverProperties());
+		assertThat(provider.newNameResolver(new URI("dns:///orders-service"), args())).isNull();
+	}
+
+	private static DefaultServiceInstance instance(String serviceId, String host, int port,
+			Map<String, String> metadata) {
+		DefaultServiceInstance instance = new DefaultServiceInstance(serviceId + "-" + host + "-" + port, serviceId,
+				host, port, false, metadata);
+		return instance;
+	}
+
+	private static NameResolver.Args args() {
+		return NameResolver.Args.newBuilder()
+			.setDefaultPort(443)
+			.setProxyDetector((targetAddress) -> null)
+			.setSynchronizationContext(new SynchronizationContext((t, e) -> {
+			}))
+			.setServiceConfigParser(new NameResolver.ServiceConfigParser() {
+				@Override
+				public NameResolver.ConfigOrError parseServiceConfig(Map<String, ?> serviceConfig) {
+					return NameResolver.ConfigOrError.fromConfig(serviceConfig);
+				}
+			})
+			.setOffloadExecutor(Runnable::run)
+			.build();
+	}
+
+}

--- a/spring-grpc-spring-cloud/src/test/java/org/springframework/grpc/client/discovery/DiscoveryNameResolverRefresherTests.java
+++ b/spring-grpc-spring-cloud/src/test/java/org/springframework/grpc/client/discovery/DiscoveryNameResolverRefresherTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.grpc.client.discovery;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.cloud.client.discovery.event.HeartbeatEvent;
+
+/**
+ * Tests for {@link DiscoveryNameResolverRefresher}.
+ */
+class DiscoveryNameResolverRefresherTests {
+
+	@Test
+	void heartbeatRefreshesAllResolvers() {
+		DiscoveryClientNameResolverProvider provider = mock(DiscoveryClientNameResolverProvider.class);
+		var refresher = new DiscoveryNameResolverRefresher(provider);
+		refresher.onHeartbeat(new HeartbeatEvent(this, "test"));
+		verify(provider).refreshAll("heartbeat-event");
+	}
+
+}

--- a/spring-grpc-spring-cloud/src/test/java/org/springframework/grpc/client/discovery/DiscoveryNameResolverRegistrarBeanFactoryPostProcessorTests.java
+++ b/spring-grpc-spring-cloud/src/test/java/org/springframework/grpc/client/discovery/DiscoveryNameResolverRegistrarBeanFactoryPostProcessorTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.grpc.client.discovery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.grpc.client.ChannelBuilderOptions;
+import org.springframework.grpc.client.GrpcChannelFactory;
+
+import io.grpc.ManagedChannel;
+
+/**
+ * Tests for {@link DiscoveryNameResolverRegistrarBeanFactoryPostProcessor}.
+ */
+class DiscoveryNameResolverRegistrarBeanFactoryPostProcessorTests {
+
+	@Test
+	void addsRegistrarDependencyToGrpcChannelFactoryBeans() {
+		var beanFactory = new org.springframework.beans.factory.support.DefaultListableBeanFactory();
+		beanFactory.registerBeanDefinition("discoveryNameResolverRegistrar",
+				new RootBeanDefinition(DiscoveryNameResolverRegistrar.class));
+		RootBeanDefinition channelFactoryBeanDefinition = new RootBeanDefinition(TestGrpcChannelFactory.class);
+		channelFactoryBeanDefinition.setDependsOn("existingDependency");
+		beanFactory.registerBeanDefinition("grpcChannelFactory", channelFactoryBeanDefinition);
+		var postProcessor = new DiscoveryNameResolverRegistrarBeanFactoryPostProcessor(
+				"discoveryNameResolverRegistrar");
+		postProcessor.postProcessBeanFactory(beanFactory);
+		assertThat(beanFactory.getBeanDefinition("grpcChannelFactory").getDependsOn())
+			.containsExactly("existingDependency", "discoveryNameResolverRegistrar");
+	}
+
+	static class TestGrpcChannelFactory implements GrpcChannelFactory {
+
+		@Override
+		public ManagedChannel createChannel(String target, ChannelBuilderOptions options) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean supports(String target) {
+			return false;
+		}
+
+		@Override
+		public boolean supports(io.grpc.ClientInterceptor interceptor) {
+			return false;
+		}
+
+	}
+
+}

--- a/spring-grpc-spring-cloud/src/test/java/org/springframework/grpc/client/discovery/GrpcPortMetadataRegistrationBeanPostProcessorTests.java
+++ b/spring-grpc-spring-cloud/src/test/java/org/springframework/grpc/client/discovery/GrpcPortMetadataRegistrationBeanPostProcessorTests.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.grpc.client.discovery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.cloud.client.serviceregistry.Registration;
+
+/**
+ * Tests for {@link GrpcPortMetadataRegistrationBeanPostProcessor}.
+ */
+class GrpcPortMetadataRegistrationBeanPostProcessorTests {
+
+	@Test
+	void publishesGrpcPortMetadataToRegistration() {
+		var registration = new TestRegistration();
+		var postProcessor = new GrpcPortMetadataRegistrationBeanPostProcessor(9091);
+		postProcessor.postProcessAfterInitialization(registration, "registration");
+		assertThat(registration.getMetadata()).containsEntry(GrpcDiscoveryConstants.GRPC_PORT_METADATA_KEY, "9091");
+	}
+
+	static class TestRegistration implements Registration {
+
+		private final Map<String, String> metadata = new LinkedHashMap<>();
+
+		@Override
+		public String getServiceId() {
+			return "test-service";
+		}
+
+		@Override
+		public String getHost() {
+			return "127.0.0.1";
+		}
+
+		@Override
+		public int getPort() {
+			return 8080;
+		}
+
+		@Override
+		public boolean isSecure() {
+			return false;
+		}
+
+		@Override
+		public URI getUri() {
+			return URI.create("http://127.0.0.1:8080");
+		}
+
+		@Override
+		public Map<String, String> getMetadata() {
+			return this.metadata;
+		}
+
+	}
+
+}

--- a/spring-grpc-spring-cloud/src/test/java/org/springframework/grpc/client/discovery/autoconfigure/DiscoveryClientNameResolverAutoConfigurationTests.java
+++ b/spring-grpc-spring-cloud/src/test/java/org/springframework/grpc/client/discovery/autoconfigure/DiscoveryClientNameResolverAutoConfigurationTests.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.grpc.client.discovery.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.grpc.client.discovery.DiscoveryClientNameResolverProvider;
+import org.springframework.grpc.client.discovery.DiscoveryNameResolverRefresher;
+import org.springframework.grpc.client.discovery.DiscoveryNameResolverRegistrar;
+import org.springframework.test.context.support.TestPropertySourceUtils;
+
+/**
+ * Tests for {@link DiscoveryClientNameResolverAutoConfiguration}.
+ */
+class DiscoveryClientNameResolverAutoConfigurationTests {
+
+	@Test
+	void autoConfigurationBacksOffWithoutDiscoveryClient() {
+		try (var context = new AnnotationConfigApplicationContext()) {
+			context.register(DiscoveryClientNameResolverAutoConfiguration.class);
+			context.refresh();
+			assertThat(context.getBeansOfType(DiscoveryClientNameResolverProvider.class)).isEmpty();
+			assertThat(context.getBeansOfType(DiscoveryNameResolverRegistrar.class)).isEmpty();
+			assertThat(context.getBeansOfType(DiscoveryNameResolverRefresher.class)).isEmpty();
+		}
+	}
+
+	@Test
+	void autoConfigurationRegistersDiscoveryBeansWhenEnabled() {
+		try (var context = new AnnotationConfigApplicationContext()) {
+			context.registerBean(DiscoveryClient.class, () -> mock(DiscoveryClient.class));
+			context.register(DiscoveryClientNameResolverAutoConfiguration.class);
+			context.refresh();
+			assertThat(context.getBeansOfType(DiscoveryClientNameResolverProvider.class)).hasSize(1);
+			assertThat(context.getBeansOfType(DiscoveryNameResolverRegistrar.class)).hasSize(1);
+			assertThat(context.getBeansOfType(DiscoveryNameResolverRefresher.class)).hasSize(1);
+		}
+	}
+
+	@Test
+	void autoConfigurationCanBeDisabled() {
+		try (var context = new AnnotationConfigApplicationContext()) {
+			TestPropertySourceUtils.addInlinedPropertiesToEnvironment(context,
+					"spring.grpc.client.discovery.enabled=false");
+			context.registerBean(DiscoveryClient.class, () -> mock(DiscoveryClient.class));
+			context.register(DiscoveryClientNameResolverAutoConfiguration.class);
+			context.refresh();
+			assertThat(context.getBeansOfType(DiscoveryClientNameResolverProvider.class)).isEmpty();
+		}
+	}
+
+}

--- a/spring-grpc-spring-cloud/src/test/java/org/springframework/grpc/client/discovery/autoconfigure/DiscoveryClientNameResolverAutoConfigurationTests.java
+++ b/spring-grpc-spring-cloud/src/test/java/org/springframework/grpc/client/discovery/autoconfigure/DiscoveryClientNameResolverAutoConfigurationTests.java
@@ -23,9 +23,12 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.grpc.client.GrpcChannelFactory;
 import org.springframework.grpc.client.discovery.DiscoveryClientNameResolverProvider;
 import org.springframework.grpc.client.discovery.DiscoveryNameResolverRefresher;
 import org.springframework.grpc.client.discovery.DiscoveryNameResolverRegistrar;
+import org.springframework.grpc.client.discovery.GrpcDiscoveryConstants;
+import org.springframework.grpc.client.discovery.GrpcPortMetadataRegistrationBeanPostProcessor;
 import org.springframework.test.context.support.TestPropertySourceUtils;
 
 /**
@@ -66,6 +69,88 @@ class DiscoveryClientNameResolverAutoConfigurationTests {
 			context.refresh();
 			assertThat(context.getBeansOfType(DiscoveryClientNameResolverProvider.class)).isEmpty();
 		}
+	}
+
+	@Test
+	void channelFactoryDependsOnDiscoveryRegistrar() {
+		try (var context = new AnnotationConfigApplicationContext()) {
+			context.registerBean(DiscoveryClient.class, () -> mock(DiscoveryClient.class));
+			context.registerBean("grpcChannelFactory", GrpcChannelFactory.class, () -> mock(GrpcChannelFactory.class));
+			context.register(DiscoveryClientNameResolverAutoConfiguration.class);
+			context.refresh();
+			assertThat(context.getBeanFactory().getBeanDefinition("grpcChannelFactory").getDependsOn())
+				.contains("discoveryNameResolverRegistrar");
+		}
+	}
+
+	@Test
+	void serviceRegistrationMetadataIsPublishedWhenEnabled() {
+		try (var context = new AnnotationConfigApplicationContext()) {
+			TestPropertySourceUtils.addInlinedPropertiesToEnvironment(context, "spring.grpc.server.port=9091");
+			context.register(TestRegistrationConfiguration.class, GrpcDiscoveryServiceRegistryAutoConfiguration.class);
+			context.refresh();
+			TestRegistration registration = context.getBean(TestRegistration.class);
+			assertThat(registration.getMetadata()).containsEntry(GrpcDiscoveryConstants.GRPC_PORT_METADATA_KEY, "9091");
+			assertThat(context.getBeansOfType(GrpcPortMetadataRegistrationBeanPostProcessor.class)).hasSize(1);
+		}
+	}
+
+	@Test
+	void serviceRegistrationMetadataPublicationCanBeDisabled() {
+		try (var context = new AnnotationConfigApplicationContext()) {
+			TestPropertySourceUtils.addInlinedPropertiesToEnvironment(context, "spring.grpc.server.port=9091",
+					"spring.grpc.server.discovery.publish-metadata=false");
+			context.register(TestRegistrationConfiguration.class, GrpcDiscoveryServiceRegistryAutoConfiguration.class);
+			context.refresh();
+			TestRegistration registration = context.getBean(TestRegistration.class);
+			assertThat(registration.getMetadata()).doesNotContainKey(GrpcDiscoveryConstants.GRPC_PORT_METADATA_KEY);
+			assertThat(context.getBeansOfType(GrpcPortMetadataRegistrationBeanPostProcessor.class)).isEmpty();
+		}
+	}
+
+	static class TestRegistrationConfiguration {
+
+		@org.springframework.context.annotation.Bean
+		TestRegistration registration() {
+			return new TestRegistration();
+		}
+
+	}
+
+	static class TestRegistration implements org.springframework.cloud.client.serviceregistry.Registration {
+
+		private final java.util.Map<String, String> metadata = new java.util.LinkedHashMap<>();
+
+		@Override
+		public String getServiceId() {
+			return "test-service";
+		}
+
+		@Override
+		public String getHost() {
+			return "127.0.0.1";
+		}
+
+		@Override
+		public int getPort() {
+			return 8080;
+		}
+
+		@Override
+		public boolean isSecure() {
+			return false;
+		}
+
+		@Override
+		public java.net.URI getUri() {
+			return java.net.URI.create("http://127.0.0.1:8080");
+		}
+
+		@Override
+		public java.util.Map<String, String> getMetadata() {
+			return this.metadata;
+		}
+
 	}
 
 }


### PR DESCRIPTION
## Summary
- add a vendor-neutral Spring Cloud discovery module for gRPC clients
- resolve `discovery:///service-name` targets through `DiscoveryClient`
- make the integration work end to end when the same module is also present on the server side

## What This Adds
- auto-configure a `NameResolverProvider` backed by Spring Cloud `DiscoveryClient`
- refresh resolved addresses when Spring Cloud publishes a `HeartbeatEvent`
- prefer the `gRPC_port` metadata entry and fall back to the service instance port
- publish `spring.grpc.server.port` as `gRPC_port` metadata through the Spring Cloud `Registration` abstraction when metadata is mutable
- register the discovery resolver before eager `GrpcChannelFactory` initialization so `discovery:///...` channels can be created during application startup
- keep the implementation generic to Spring Cloud instead of introducing a registry-specific starter

## Configuration
Client side:
- `spring.grpc.client.discovery.enabled=true`
- `spring.grpc.client.discovery.load-balancing-policy=round_robin`
- `spring.grpc.client.channels.<name>.address=discovery:///service-name`

Server side:
- `spring.grpc.server.port=9091`
- optional opt-out: `spring.grpc.server.discovery.publish-metadata=false`

## Verification
Automated:
- `JAVA_HOME=/usr/local/java/jdk-25.0.2.jdk/Contents/Home ./mvnw -Dmaven.repo.local=/Users/hyacinth/myRes/hurricane/project_dd/jdk25reposiory -pl spring-grpc-spring-cloud -am test`

Manual:
- validated locally with Spring Cloud Alibaba Nacos using only Spring Cloud Discovery integration plus this module, without a registry-specific gRPC discovery starter

Fixes #341
