### PR TITLE
Remove static:// prefix from VirtualTargets.DEFAULT

### DIFF
--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/VirtualTargets.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/VirtualTargets.java
@@ -16,20 +16,13 @@
 
 package org.springframework.grpc.client;
 
-import java.util.regex.Pattern;
-
 public interface VirtualTargets {
 
-	/** Regex to match the default authority pattern. */
-	Pattern AUTHORITY_PATTERN = Pattern.compile("([^:]+)(?::(\\d+))?");
-
-	/** Default VirtualTargets instance. */
-	VirtualTargets DEFAULT = path -> {
-		if (AUTHORITY_PATTERN.matcher(path).matches()) {
-			return "static://" + path;
-		}
-		return path;
-	};
+	/**
+	 * Default VirtualTargets instance that resolves the logical name "default" to
+	 * "localhost:9090" and returns all other targets as-is.
+	 */
+	VirtualTargets DEFAULT = path -> "default".equals(path) ? "localhost:9090" : path;
 
 	String getTarget(String path);
 

--- a/spring-grpc-core/src/test/java/org/springframework/grpc/client/DefaultGrpcChannelFactoryTests.java
+++ b/spring-grpc-core/src/test/java/org/springframework/grpc/client/DefaultGrpcChannelFactoryTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.grpc.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link DefaultGrpcChannelFactory}.
+ *
+ * @author Andrey Litvitski
+ */
+class DefaultGrpcChannelFactoryTests {
+
+	@Test
+	void defaultTargetResolvesToLocalhost() {
+		var factory = new DefaultGrpcChannelFactory<>(List.of(), mock());
+		assertThat(factory.targets).isSameAs(VirtualTargets.DEFAULT);
+		assertThat(factory.targets.getTarget("default")).isEqualTo("localhost:9090");
+	}
+
+}


### PR DESCRIPTION
The static:// prefix is not a valid gRPC scheme and causes `IllegalArgumentException` when using `@ImportGrpcClients` without Spring Boot. Replace the prefix logic with a simple resolution of `"default"` to `"localhost:9090"`.

References: gh-401