### PR TITLE
Fix missing link to the migration guide

### DIFF
--- a/spring-grpc-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-grpc-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -7,7 +7,7 @@
 
 This section covers the changes made from version 1.0.0 to version 1.1.0.
 
-* Spring Boot autoconfiguration and starters were moved to Spring Boot - see the upgrade guide for more details
+* Spring Boot autoconfiguration and starters were moved to Spring Boot - see the https://github.com/spring-projects/spring-grpc/wiki/Spring-gRPC-1.1-Migration-Guide[migration guide] for more details
 
 [[what-s-new-in-1.0.0-since-0-9-0]]
 == What's New in 1.0.0 Since 0.9.0


### PR DESCRIPTION
See https://github.com/spring-projects/spring-boot/issues/49830#issuecomment-4307542495