### PR TITLE
Move `AUTHORIZATION_KEY` out of `GrpcSecurity` to avoid `ClassNotFoundException`

### DIFF
--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/interceptor/security/BasicAuthenticationInterceptor.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/interceptor/security/BasicAuthenticationInterceptor.java
@@ -18,7 +18,7 @@ package org.springframework.grpc.client.interceptor.security;
 
 import java.util.Base64;
 
-import org.springframework.grpc.server.security.GrpcSecurity;
+import org.springframework.grpc.internal.GrpcHeaders;
 
 import io.grpc.CallOptions;
 import io.grpc.Channel;
@@ -50,7 +50,7 @@ public class BasicAuthenticationInterceptor implements ClientInterceptor {
 			CallOptions callOptions, Channel next) {
 		return new SimpleForwardingClientCall<>(next.newCall(method, callOptions)) {
 			public void start(ClientCall.Listener<RespT> responseListener, io.grpc.Metadata headers) {
-				headers.put(GrpcSecurity.AUTHORIZATION_KEY,
+				headers.put(GrpcHeaders.AUTHORIZATION_KEY,
 						"Basic " + Base64.getEncoder()
 							.encodeToString((BasicAuthenticationInterceptor.this.username + ":"
 									+ BasicAuthenticationInterceptor.this.password)

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/client/interceptor/security/BearerTokenAuthenticationInterceptor.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/client/interceptor/security/BearerTokenAuthenticationInterceptor.java
@@ -18,7 +18,7 @@ package org.springframework.grpc.client.interceptor.security;
 
 import java.util.function.Supplier;
 
-import org.springframework.grpc.server.security.GrpcSecurity;
+import org.springframework.grpc.internal.GrpcHeaders;
 
 import io.grpc.CallOptions;
 import io.grpc.Channel;
@@ -49,7 +49,7 @@ public class BearerTokenAuthenticationInterceptor implements ClientInterceptor {
 			CallOptions callOptions, Channel next) {
 		return new SimpleForwardingClientCall<>(next.newCall(method, callOptions)) {
 			public void start(ClientCall.Listener<RespT> responseListener, io.grpc.Metadata headers) {
-				headers.put(GrpcSecurity.AUTHORIZATION_KEY,
+				headers.put(GrpcHeaders.AUTHORIZATION_KEY,
 						"Bearer " + BearerTokenAuthenticationInterceptor.this.token.get());
 				super.start(responseListener, headers);
 			}

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/internal/GrpcHeaders.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/internal/GrpcHeaders.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.grpc.internal;
+
+import io.grpc.Metadata;
+
+/**
+ * Common gRPC headers.
+ * <p>
+ * NOTE: Even though this class visibility is `public` it is intended for internal use
+ * only and not recommended for direct use.
+ *
+ * @author Andrey Litvitski
+ */
+public final class GrpcHeaders {
+
+	private GrpcHeaders() {
+	}
+
+	/**
+	 * A constant key used for storing and retrieving the "Authorization" header from gRPC
+	 * metadata. This key is used to handle authorization information in gRPC requests.
+	 *
+	 * <p>
+	 * The key is defined with the name "Authorization" and uses the ASCII string
+	 * marshaller for encoding and decoding the header value.
+	 * </p>
+	 */
+	public static final Metadata.Key<String> AUTHORIZATION_KEY = Metadata.Key.of("Authorization",
+			Metadata.ASCII_STRING_MARSHALLER);
+
+}

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/BearerTokenAuthenticationExtractor.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/BearerTokenAuthenticationExtractor.java
@@ -20,6 +20,7 @@ import java.util.Locale;
 
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.grpc.internal.GrpcHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthenticationToken;
@@ -41,7 +42,7 @@ public class BearerTokenAuthenticationExtractor implements GrpcAuthenticationExt
 
 	@Override
 	public @Nullable Authentication extract(Metadata headers, Attributes attributes, MethodDescriptor<?, ?> method) {
-		String auth = headers.get(GrpcSecurity.AUTHORIZATION_KEY);
+		String auth = headers.get(GrpcHeaders.AUTHORIZATION_KEY);
 		if (auth == null) {
 			return null;
 		}

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/GrpcSecurity.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/GrpcSecurity.java
@@ -62,18 +62,6 @@ public final class GrpcSecurity
 		extends AbstractConfiguredSecurityBuilder<AuthenticationProcessInterceptor, GrpcSecurity> {
 
 	/**
-	 * A constant key used for storing and retrieving the "Authorization" header from gRPC
-	 * metadata. This key is used to handle authorization information in gRPC requests.
-	 *
-	 * <p>
-	 * The key is defined with the name "Authorization" and uses the ASCII string
-	 * marshaller for encoding and decoding the header value.
-	 * </p>
-	 */
-	public static final Metadata.Key<String> AUTHORIZATION_KEY = Metadata.Key.of("Authorization",
-			Metadata.ASCII_STRING_MARSHALLER);
-
-	/**
 	 * The order value for the context filter in the gRPC security framework. This
 	 * constant defines the position of the context filter in the filter chain. A lower
 	 * value indicates higher precedence.

--- a/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/HttpBasicAuthenticationExtractor.java
+++ b/spring-grpc-core/src/main/java/org/springframework/grpc/server/security/HttpBasicAuthenticationExtractor.java
@@ -22,6 +22,7 @@ import java.util.Locale;
 
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.grpc.internal.GrpcHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 
@@ -42,7 +43,7 @@ public class HttpBasicAuthenticationExtractor implements GrpcAuthenticationExtra
 
 	@Override
 	public @Nullable Authentication extract(Metadata headers, Attributes attributes, MethodDescriptor<?, ?> method) {
-		String auth = headers.get(GrpcSecurity.AUTHORIZATION_KEY);
+		String auth = headers.get(GrpcHeaders.AUTHORIZATION_KEY);
 		if (auth == null) {
 			return null;
 		}


### PR DESCRIPTION
The problem is that we don’t include the `spring-security` module in the client's auto-configuration, which causes a `ClassNotFoundException` when we try to use any of its constants. In our case, this is `GrpcSecurity#AUTHORIZATION_KEY`, and since client modules use it, we need to move it out. In our case, I moved it to a separate internal class called `GrpcMetadataKeys`.

Closes: gh-409